### PR TITLE
Fixes #6 by adding a limit of 100 items within the RequestCache

### DIFF
--- a/src/main/java/com/ontotext/trree/plugin/mongodb/MongoResultIterator.java
+++ b/src/main/java/com/ontotext/trree/plugin/mongodb/MongoResultIterator.java
@@ -123,6 +123,10 @@ public class MongoResultIterator extends StatementIterator {
 		client = null;
 
 		interrupted = true;
+		if (currentRDF != null) {
+			currentRDF.clear();
+			currentRDF = null;
+		}
 	}
 
 	public void setQuery(String query) {

--- a/src/main/java/com/ontotext/trree/plugin/mongodb/RequestCache.java
+++ b/src/main/java/com/ontotext/trree/plugin/mongodb/RequestCache.java
@@ -5,17 +5,28 @@ import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoCollection;
 import org.bson.Document;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Caches the aggregate and find calls to mongo in each request.
  */
 public class RequestCache {
 
-	protected HashMap<Integer, AggregateIterable<Document>> aggregateCache = new HashMap<>();
-	protected HashMap<Integer, FindIterable<Document>> findCache = new HashMap<>();
-
+	final int MAX_ITEMS = 100;
+	final static float FACTOR = 0.75f;
+	protected Map<Integer, AggregateIterable<Document>> aggregateCache = boundCache(MAX_ITEMS);
+	protected Map<Integer, FindIterable<Document>> findCache = boundCache(MAX_ITEMS);
+	
+	public static <K,V> Map<K,V> boundCache(final int maxSize) {
+        return new LinkedHashMap<K,V>((int)(maxSize/FACTOR), FACTOR, true) {
+            @Override
+            protected boolean removeEldestEntry(Map.Entry<K,V> eldest) {
+            	return size() > maxSize;
+            }
+        };
+    }
 	AggregateIterable<Document> getAggregation(MongoCollection coll, String database, String collection, List<Document> aggregation) {
 		return aggregateCache
 				.computeIfAbsent(database.hashCode() ^ collection.hashCode() ^ aggregation.hashCode()


### PR DESCRIPTION
 - limit cache for aggreagtes and searches to 100
 - clear current RDF document when the main iterator is closed
 - related to GDB-6954