### PR TITLE
GDB-7554: Fixed query to order result when test expects them to be or…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<description>MongoDB plugin for GraphDB</description>
 
 	<properties>
-		<graphdb.version>10.0.3</graphdb.version>
+		<graphdb.version>10.1.0-RC3</graphdb.version>
 		<dependency.check.version>6.2.2</dependency.check.version>
 
 		<java.level>1.8</java.level>

--- a/src/test/resources/mongodb/queries/mongo_query5.txt
+++ b/src/test/resources/mongodb/queries/mongo_query5.txt
@@ -72,4 +72,4 @@ WHERE {
     }
 }
 GROUP BY ?topic
-ORDER BY DESC(?cnt)
+ORDER BY DESC(?cnt) ?topic


### PR DESCRIPTION
…dered - for some reason previous GraphDB versions happened to provide the expected order without explicit ordering

- Also upgraded GraphDB dep to 10.1.0-RC3