### PR TITLE
GDB-7684: Support expression values for mongo query configs

### DIFF
--- a/src/main/java/com/ontotext/trree/plugin/mongodb/MongoDBPlugin.java
+++ b/src/main/java/com/ontotext/trree/plugin/mongodb/MongoDBPlugin.java
@@ -367,15 +367,15 @@ public class MongoDBPlugin extends PluginBase implements Preprocessor, PatternIn
 				return StatementIterator.EMPTY;
 			}
 
-      String aggregationString = Utils.getString(entities, object);
+			String aggregationString = Utils.getString(entities, object);
 
-      if (aggregationString == null) {
-        // make sure to mark the aggregate parameter as lazy set
-        // this will ensure the main iterator would not be closed before setting this.
-        MongoResultIterator iter = getIterator(subject, context, ctx);
-        iter.setAggregation(null);
-        return iter.singletonIterator(aggregationId, object);
-      }
+			if (aggregationString == null) {
+				// make sure to mark the aggregate parameter as lazy set
+				// this will ensure the main iterator would not be closed before setting this.
+				MongoResultIterator iter = getIterator(subject, context, ctx);
+				iter.setAggregation(null);
+				return iter.singletonIterator(aggregationId, object);
+			}
 
 			List<Document> aggregation = new LinkedList<>();
 			try {

--- a/src/main/java/com/ontotext/trree/plugin/mongodb/MongoResultIterator.java
+++ b/src/main/java/com/ontotext/trree/plugin/mongodb/MongoResultIterator.java
@@ -77,10 +77,10 @@ public class MongoResultIterator extends StatementIterator {
 	private boolean interrupted = false;
 	private boolean closed = false;
 	// if some of the query components are constructed with a function
-  // and set using bind the first time they are visited will be null. If we have setter with null
-  // then we can expect the value to be set later on, but the original iterator would be closed
-  // this property prevents the iterator to be closed the first time if any of the
-  // set components are null (query, hint, projection, collation, aggregation)
+	// and set using bind the first time they are visited will be null. If we have setter with null
+	// then we can expect the value to be set later on, but the original iterator would be closed
+	// this property prevents the iterator to be closed the first time if any of the
+	// set components are null (query, hint, projection, collation, aggregation)
 	private boolean closeable = true;
 
 	public MongoResultIterator(MongoDBPlugin plugin, MongoClient client, String database, String collection, RequestCache cache, long searchsubject) {
@@ -166,11 +166,11 @@ public class MongoResultIterator extends StatementIterator {
 
 	@Override
 	public void close() {
-	  if (!closeable) {
-	    // prevent closing the iterator if not fully configured
-	    closeable = true;
-	    return;
-    }
+		if (!closeable) {
+			// prevent closing the iterator if not fully configured
+			closeable = true;
+			return;
+		}
 
 		closed = true;
 		if (iter != null)
@@ -193,7 +193,7 @@ public class MongoResultIterator extends StatementIterator {
 
 	public void setQuery(String query) {
 		this.query = query;
-    closeable &= query != null;
+		closeable &= query != null;
 	}
 
 	public StatementIterator singletonIterator(long predicate, long object) {
@@ -202,7 +202,7 @@ public class MongoResultIterator extends StatementIterator {
 
 	public void setProjection(String projectionString) {
 		this.projection = projectionString;
-    closeable &= projection != null;
+		closeable &= projection != null;
 	}
 
 	public StatementIterator createEntityIter(long pred) {
@@ -477,7 +477,7 @@ public class MongoResultIterator extends StatementIterator {
 
 	public void setAggregation(List<Document> aggregation) {
 		this.aggregation = aggregation;
-    closeable &= aggregation != null;
+		closeable &= aggregation != null;
 	}
 
 	public void setGraphId(long graphId) {
@@ -511,12 +511,12 @@ public class MongoResultIterator extends StatementIterator {
 
 	public void setHint(String hintString) {
 		this.hint = hintString;
-    closeable &= hint != null;
+		closeable &= hint != null;
 	}
 
 	public void setCollation(String collationString){
-    closeable &= collationString != null;
-    setCollation(createCollation(collationString));
+		closeable &= collationString != null;
+		setCollation(createCollation(collationString));
 	}
 
 	public Collation getCollation() {

--- a/src/test/java/com/ontotext/trree/plugin/mongodb/AbstractMongoBasicTest.java
+++ b/src/test/java/com/ontotext/trree/plugin/mongodb/AbstractMongoBasicTest.java
@@ -127,7 +127,7 @@ public abstract class AbstractMongoBasicTest extends AbstractMongoTest {
 	/**
 	 * Executes a query and verifies the result count is correct
 	 *
-	 * @param query                query to be executed
+	 * @param query								query to be executed
 	 * @param expectedResultsCount
 	 */
 	protected void verifyResultsCount(String query, int expectedResultsCount) {
@@ -158,8 +158,8 @@ public abstract class AbstractMongoBasicTest extends AbstractMongoTest {
 	 * will wither compare the result of the query or generate new output files. <p>
 	 * As the comparison is exact one make sure you do not have any blank nodes in the result!
 	 *
-	 * @param query       query to be executed
-	 * @param resultFile file  containing the output to be compared against.
+	 * @param query			 query to be executed
+	 * @param resultFile file	containing the output to be compared against.
 	 */
 	protected void verifyOrderedResult(String query, File resultFile) throws Exception {
 		verifyResult(query, resultFile, true);
@@ -169,16 +169,16 @@ public abstract class AbstractMongoBasicTest extends AbstractMongoTest {
 	 * Executes a query verifies the output matches a given one no matter the order in which the bindings come. Depending
 	 * on the LEARN_MODE setting this method will wither compare the result of the query or generate new output files. <p>
 	 *
-	 * @param query       query to be executed
+	 * @param query			 query to be executed
 	 * @param resultFile file containing the output to be compared against.
 	 */
 	protected void verifyUnorderedResult(String query, File resultFile) throws Exception {
 		verifyResult(query, resultFile, false);
 	}
 
-  protected void verifyResult(String resultFile, boolean ordered) throws Exception {
-	  verifyResult(query, RESULTS_DIR.resolve(this.getClass().getSimpleName()).resolve(resultFile).toFile(), ordered);
-  }
+	protected void verifyResult(String resultFile, boolean ordered) throws Exception {
+		verifyResult(query, RESULTS_DIR.resolve(this.getClass().getSimpleName()).resolve(resultFile).toFile(), ordered);
+	}
 
 	protected void verifyResult(String query, File resultFile, boolean ordered) throws Exception {
 		try (RepositoryConnection conn = getRepository().getConnection()) {
@@ -262,8 +262,8 @@ public abstract class AbstractMongoBasicTest extends AbstractMongoTest {
 	/**
 	 * Determines whether the methods which compare query results against given output generate the output or do the
 	 * actual comparing<p>
-	 *     When running the actual tests this should always return false and can be set to true only when writing new
-	 *     test cases.
+	 *		 When running the actual tests this should always return false and can be set to true only when writing new
+	 *		 test cases.
 	 * @return
 	 */
 	protected boolean isLearnMode() {

--- a/src/test/java/com/ontotext/trree/plugin/mongodb/AbstractMongoBasicTest.java
+++ b/src/test/java/com/ontotext/trree/plugin/mongodb/AbstractMongoBasicTest.java
@@ -176,6 +176,10 @@ public abstract class AbstractMongoBasicTest extends AbstractMongoTest {
 		verifyResult(query, resultFile, false);
 	}
 
+  protected void verifyResult(String resultFile, boolean ordered) throws Exception {
+	  verifyResult(query, RESULTS_DIR.resolve(this.getClass().getSimpleName()).resolve(resultFile).toFile(), ordered);
+  }
+
 	protected void verifyResult(String query, File resultFile, boolean ordered) throws Exception {
 		try (RepositoryConnection conn = getRepository().getConnection()) {
 

--- a/src/test/java/com/ontotext/trree/plugin/mongodb/TestPluginMongoBasicQueries.java
+++ b/src/test/java/com/ontotext/trree/plugin/mongodb/TestPluginMongoBasicQueries.java
@@ -28,6 +28,61 @@ public class TestPluginMongoBasicQueries extends AbstractMongoBasicTest {
 		verifyUnorderedResult();
 	}
 
+  @Test
+  public void testGetResultsFromDocumentById_withValues() throws Exception {
+    query = "PREFIX : <http://www.ontotext.com/connectors/mongodb#>\r\n" +
+            "PREFIX inst: <http://www.ontotext.com/connectors/mongodb/instance#>\r\n" +
+            "select ?s ?o {\n"
+            + "\tVALUES ?query {\"{'@id' : 'bbcc:1646461#id'}\"}."
+            + "\t?search a inst:spb100 ;\n"
+            + "\t:find  ?query;"
+            + "\t:project '{ \"@context\": 1, \"cwork:about\": 1, \"@type\": 1, \"@id\" : 1, \"@graph\" : 1 }' ;"
+            + "\t:entity ?entity .\n"
+            + "\tgraph inst:spb100 {\n"
+            + "\t\t?s <http://www.bbc.co.uk/ontologies/creativework/about> ?o .\n"
+            + "\t}\n"
+            + "}";
+
+    verifyResult("testGetResultsFromDocumentById", false);
+  }
+
+  @Test
+  public void testGetResultsFromDocumentById_withBind() throws Exception {
+    query = "PREFIX : <http://www.ontotext.com/connectors/mongodb#>\r\n" +
+            "PREFIX inst: <http://www.ontotext.com/connectors/mongodb/instance#>\r\n" +
+            "select ?s ?o {\n"
+            + "BIND(\"{'@id' : 'bbcc:1646461#id'}\" as ?query)."
+            + "\t?search a inst:spb100 ;\n"
+            + "\t:find  ?query;"
+            + "\t:project '{ \"@context\": 1, \"cwork:about\": 1, \"@type\": 1, \"@id\" : 1, \"@graph\" : 1 }' ;"
+            + "\t:entity ?entity .\n"
+            + "\tgraph inst:spb100 {\n"
+            + "\t\t?s <http://www.bbc.co.uk/ontologies/creativework/about> ?o .\n"
+            + "\t}\n"
+            + "}";
+
+    verifyResult("testGetResultsFromDocumentById", false);
+  }
+
+  @Test
+  public void testGetResultsFromDocumentById_withBind2() throws Exception {
+    query = "PREFIX : <http://www.ontotext.com/connectors/mongodb#>\r\n" +
+            "PREFIX inst: <http://www.ontotext.com/connectors/mongodb/instance#>\r\n" +
+            "select ?s ?o {\n"
+            + "\tBIND(\"{'@id' : 'bbcc:1646461#id'}\" as ?query)."
+            + "\tBIND('{ \"@context\": 1, \"cwork:about\": 1, \"@type\": 1, \"@id\" : 1, \"@graph\" : 1 }' as ?projection)."
+            + "\t?search a inst:spb100 ;\n"
+            + "\t:find  ?query ;"
+            + "\t:project ?projection ;"
+            + "\t:entity ?entity .\n"
+            + "\tgraph inst:spb100 {\n"
+            + "\t\t?s <http://www.bbc.co.uk/ontologies/creativework/about> ?o .\n"
+            + "\t}\n"
+            + "}";
+
+    verifyResult("testGetResultsFromDocumentById", false);
+  }
+
 	@Test
 	public void testAggregation() throws Exception {
 		query = "PREFIX : <http://www.ontotext.com/connectors/mongodb#>\r\n" +

--- a/src/test/java/com/ontotext/trree/plugin/mongodb/TestPluginMongoBasicQueries.java
+++ b/src/test/java/com/ontotext/trree/plugin/mongodb/TestPluginMongoBasicQueries.java
@@ -28,60 +28,60 @@ public class TestPluginMongoBasicQueries extends AbstractMongoBasicTest {
 		verifyUnorderedResult();
 	}
 
-  @Test
-  public void testGetResultsFromDocumentById_withValues() throws Exception {
-    query = "PREFIX : <http://www.ontotext.com/connectors/mongodb#>\r\n" +
-            "PREFIX inst: <http://www.ontotext.com/connectors/mongodb/instance#>\r\n" +
-            "select ?s ?o {\n"
-            + "\tVALUES ?query {\"{'@id' : 'bbcc:1646461#id'}\"}."
-            + "\t?search a inst:spb100 ;\n"
-            + "\t:find  ?query;"
-            + "\t:project '{ \"@context\": 1, \"cwork:about\": 1, \"@type\": 1, \"@id\" : 1, \"@graph\" : 1 }' ;"
-            + "\t:entity ?entity .\n"
-            + "\tgraph inst:spb100 {\n"
-            + "\t\t?s <http://www.bbc.co.uk/ontologies/creativework/about> ?o .\n"
-            + "\t}\n"
-            + "}";
+	@Test
+	public void testGetResultsFromDocumentById_withValues() throws Exception {
+		query = "PREFIX : <http://www.ontotext.com/connectors/mongodb#>\r\n" +
+						"PREFIX inst: <http://www.ontotext.com/connectors/mongodb/instance#>\r\n" +
+						"select ?s ?o {\n"
+						+ "\tVALUES ?query {\"{'@id' : 'bbcc:1646461#id'}\"}."
+						+ "\t?search a inst:spb100 ;\n"
+						+ "\t:find	?query;"
+						+ "\t:project '{ \"@context\": 1, \"cwork:about\": 1, \"@type\": 1, \"@id\" : 1, \"@graph\" : 1 }' ;"
+						+ "\t:entity ?entity .\n"
+						+ "\tgraph inst:spb100 {\n"
+						+ "\t\t?s <http://www.bbc.co.uk/ontologies/creativework/about> ?o .\n"
+						+ "\t}\n"
+						+ "}";
 
-    verifyResult("testGetResultsFromDocumentById", false);
-  }
+		verifyResult("testGetResultsFromDocumentById", false);
+	}
 
-  @Test
-  public void testGetResultsFromDocumentById_withBind() throws Exception {
-    query = "PREFIX : <http://www.ontotext.com/connectors/mongodb#>\r\n" +
-            "PREFIX inst: <http://www.ontotext.com/connectors/mongodb/instance#>\r\n" +
-            "select ?s ?o {\n"
-            + "BIND(\"{'@id' : 'bbcc:1646461#id'}\" as ?query)."
-            + "\t?search a inst:spb100 ;\n"
-            + "\t:find  ?query;"
-            + "\t:project '{ \"@context\": 1, \"cwork:about\": 1, \"@type\": 1, \"@id\" : 1, \"@graph\" : 1 }' ;"
-            + "\t:entity ?entity .\n"
-            + "\tgraph inst:spb100 {\n"
-            + "\t\t?s <http://www.bbc.co.uk/ontologies/creativework/about> ?o .\n"
-            + "\t}\n"
-            + "}";
+	@Test
+	public void testGetResultsFromDocumentById_withBind() throws Exception {
+		query = "PREFIX : <http://www.ontotext.com/connectors/mongodb#>\r\n" +
+						"PREFIX inst: <http://www.ontotext.com/connectors/mongodb/instance#>\r\n" +
+						"select ?s ?o {\n"
+						+ "BIND(\"{'@id' : 'bbcc:1646461#id'}\" as ?query)."
+						+ "\t?search a inst:spb100 ;\n"
+						+ "\t:find	?query;"
+						+ "\t:project '{ \"@context\": 1, \"cwork:about\": 1, \"@type\": 1, \"@id\" : 1, \"@graph\" : 1 }' ;"
+						+ "\t:entity ?entity .\n"
+						+ "\tgraph inst:spb100 {\n"
+						+ "\t\t?s <http://www.bbc.co.uk/ontologies/creativework/about> ?o .\n"
+						+ "\t}\n"
+						+ "}";
 
-    verifyResult("testGetResultsFromDocumentById", false);
-  }
+		verifyResult("testGetResultsFromDocumentById", false);
+	}
 
-  @Test
-  public void testGetResultsFromDocumentById_withBind2() throws Exception {
-    query = "PREFIX : <http://www.ontotext.com/connectors/mongodb#>\r\n" +
-            "PREFIX inst: <http://www.ontotext.com/connectors/mongodb/instance#>\r\n" +
-            "select ?s ?o {\n"
-            + "\tBIND(\"{'@id' : 'bbcc:1646461#id'}\" as ?query)."
-            + "\tBIND('{ \"@context\": 1, \"cwork:about\": 1, \"@type\": 1, \"@id\" : 1, \"@graph\" : 1 }' as ?projection)."
-            + "\t?search a inst:spb100 ;\n"
-            + "\t:find  ?query ;"
-            + "\t:project ?projection ;"
-            + "\t:entity ?entity .\n"
-            + "\tgraph inst:spb100 {\n"
-            + "\t\t?s <http://www.bbc.co.uk/ontologies/creativework/about> ?o .\n"
-            + "\t}\n"
-            + "}";
+	@Test
+	public void testGetResultsFromDocumentById_withBind2() throws Exception {
+		query = "PREFIX : <http://www.ontotext.com/connectors/mongodb#>\r\n" +
+						"PREFIX inst: <http://www.ontotext.com/connectors/mongodb/instance#>\r\n" +
+						"select ?s ?o {\n"
+						+ "\tBIND(\"{'@id' : 'bbcc:1646461#id'}\" as ?query)."
+						+ "\tBIND('{ \"@context\": 1, \"cwork:about\": 1, \"@type\": 1, \"@id\" : 1, \"@graph\" : 1 }' as ?projection)."
+						+ "\t?search a inst:spb100 ;\n"
+						+ "\t:find	?query ;"
+						+ "\t:project ?projection ;"
+						+ "\t:entity ?entity .\n"
+						+ "\tgraph inst:spb100 {\n"
+						+ "\t\t?s <http://www.bbc.co.uk/ontologies/creativework/about> ?o .\n"
+						+ "\t}\n"
+						+ "}";
 
-    verifyResult("testGetResultsFromDocumentById", false);
-  }
+		verifyResult("testGetResultsFromDocumentById", false);
+	}
 
 	@Test
 	public void testAggregation() throws Exception {


### PR DESCRIPTION
Added support in the MongoResultIterator to detect when any of the query components are constructed with a function and not present during the first pass of the statements. In this case the initial iterator would not be allowed to be closed and will be reused when the variables are resolved and passed to the configuration.
Any of the following parameters could be set via an expression: query, hint, projection, collation, aggregation.