### PR TITLE
GDB-11761: Add mongo connector batch processing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 target
 *.iml
 .idea
+
+# Eclipse
+.classpath
+.project
+.settings/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+## 1.2.0
+
+- [GDB-11761](https://graphwise.atlassian.net/browse/GDB-11761): Adds batch processing of the result documents
+
+  Added functionality where all documents matching the input query, up to a maximum are loaded in memory and returned as
+  named graph collection instead of processing one by one.
+  When the new functionality is used the plugin is no longer streaming but will require a buffer to store the documents
+  until the query is complete.
+
+  Added system property configuration that controls the maximum allowed batch size: `graphdb.mongodb.maxBatchSize`. This
+  is to prevent Out-of-Memory problems.
+
+  Updated the GraphDB SDK to stable a version and the Java version to 21.
+
+## 1.1.0
+
+- Makes the plugin compatible with GraphDB 11 and the new version of RDF4J.
+- Replaces the JSONLD library.
+
+## 1.0.x
+
+- Legacy versions used prior to GraphDB 11.

--- a/README.md
+++ b/README.md
@@ -18,5 +18,22 @@ External plugins are installed under `lib/plugins` in the GraphDB distribution
 directory. To install the plugin follow these steps:
 
 1. Remove the directory containing another version of the plugin from `lib/plugins` (e.g. `mongodb-plugin`).
-1. Unzip the built zip file in `lib/plugins`.
-1. Restart GraphDB. 
+2. Unzip the built zip file in `lib/plugins`.
+3. Restart GraphDB. 
+
+## Releases & Branches
+
+### Master
+
+Currently the `master` branch is used for releases compatible with the latest versions of GraphDB. This means that the
+changes should be compatible with the GraphDB SDK, Java, RDF4J, etc.
+
+### Releases/GraphDB-10.8.x
+
+There is a protected branch called `releases/graphdb-10.8.x`, which is used for plugin releases that have to be
+compatible with GraphDB 10.8.
+
+The branch is compatible with older version of the GraphDB SDK, Java 11 and RDF4J 4.
+
+The need for such branch comes from the fact that we still support some of the older GraphDB versions and sometimes we
+have to port a fix or functionality required by clients.

--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,12 @@
 			<scope>provided</scope>
 		</dependency>
 
+    <dependency>
+      <groupId>org.eclipse.collections</groupId>
+      <artifactId>eclipse-collections-api</artifactId>
+      <version>11.1.0</version>
+    </dependency>
+
 		<dependency>
 			<groupId>com.ontotext.graphdb</groupId>
 			<artifactId>graphdb-runtime</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<description>MongoDB plugin for GraphDB</description>
 
 	<properties>
-		<graphdb.version>11.0.0-RC3</graphdb.version>
+		<graphdb.version>11.0.0</graphdb.version>
 		<dependency.check.version>12.1.0</dependency.check.version>
 
 		<java.level>21</java.level>
@@ -133,11 +133,11 @@
 			<scope>provided</scope>
 		</dependency>
 
-    <dependency>
-      <groupId>org.eclipse.collections</groupId>
-      <artifactId>eclipse-collections-api</artifactId>
-      <version>11.1.0</version>
-    </dependency>
+		<dependency>
+			<groupId>org.eclipse.collections</groupId>
+			<artifactId>eclipse-collections-api</artifactId>
+			<version>11.1.0</version>
+		</dependency>
 
 		<dependency>
 			<groupId>com.ontotext.graphdb</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 		<graphdb.version>11.0.0-TR18</graphdb.version>
 		<dependency.check.version>12.1.0</dependency.check.version>
 
-		<java.level>1.8</java.level>
+		<java.level>21</java.level>
 
 		<internal.repo>https://maven.ontotext.com/content/repositories/owlim-releases</internal.repo>
 		<snapshots.repo>https://maven.ontotext.com/content/repositories/owlim-snapshots</snapshots.repo>

--- a/src/main/java/com/ontotext/trree/plugin/mongodb/BatchDocumentStore.java
+++ b/src/main/java/com/ontotext/trree/plugin/mongodb/BatchDocumentStore.java
@@ -1,0 +1,40 @@
+package com.ontotext.trree.plugin.mongodb;
+
+import org.eclipse.collections.api.iterator.LongIterator;
+import org.eclipse.collections.api.set.primitive.MutableLongSet;
+import org.eclipse.collections.api.factory.primitive.LongSets;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.impl.LinkedHashModel;
+
+/**
+ * Collects the document data during batch processing.
+ *
+ * @author <a href="mailto:borislav.bonev@ontotext.com">Borislav Bonev</a>
+ * @since 26/03/2025
+ */
+public class BatchDocumentStore {
+	private final MutableLongSet documentIds = LongSets.mutable.empty();
+	private final Model data = new LinkedHashModel();
+
+	public void addDocument(long id, Model model) {
+		documentIds.add(id);
+		data.addAll(model);
+	}
+
+	public Model getData() {
+		return data;
+	}
+
+	public void clear() {
+		documentIds.clear();
+		data.clear();
+	}
+
+	public int size() {
+		return documentIds.size();
+	}
+
+	LongIterator getIterator() {
+		return documentIds.longIterator();
+	}
+}

--- a/src/main/java/com/ontotext/trree/plugin/mongodb/CachingDocumentLoader.java
+++ b/src/main/java/com/ontotext/trree/plugin/mongodb/CachingDocumentLoader.java
@@ -6,10 +6,11 @@ import com.apicatalog.jsonld.document.Document;
 import com.apicatalog.jsonld.loader.DocumentLoader;
 import com.apicatalog.jsonld.loader.DocumentLoaderOptions;
 import com.apicatalog.jsonld.loader.SchemeRouter;
-
 import java.io.Closeable;
 import java.net.URI;
-import java.util.*;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
 
 /**
  * Custom document loader that will cache the remote documents. This will not cache regular JSON-LD
@@ -19,12 +20,15 @@ import java.util.*;
  * @since 19/10/2022
  */
 public class CachingDocumentLoader implements DocumentLoader, Closeable {
-  private static final DocumentLoader defaultLoader = SchemeRouter.defaultInstance();
+
   private static final String DISALLOW_REMOTE_CONTEXT_LOADING = "graphdb.disallow.remote.context.loading";
+  private static final DocumentLoader DEFAULT_LOADER = SchemeRouter.defaultInstance();
 
   // as the document instances are immutable we can cache them whole
-  private final Map<URI, Document> documentCache = new LinkedHashMap<URI, Document>() {
-    @Override protected boolean removeEldestEntry(Map.Entry eldest) {
+  private final Map<URI, Document> documentCache = new LinkedHashMap<>() {
+
+    @Override
+    protected boolean removeEldestEntry(Entry<URI, Document> eldest) {
       // if the cache reaches 1000 elements then the first (oldest) entity will be dropped from the cache
       // this is mainly a failsafe in case of someone tries to fill up the memory with random contexts
       return documentCache.size() > 1000;
@@ -39,21 +43,21 @@ public class CachingDocumentLoader implements DocumentLoader, Closeable {
       } catch (final Exception e) {
         throw new JsonLdError(JsonLdErrorCode.LOADING_DOCUMENT_FAILED, uri + " " + e.getMessage());
       }
-    } else {
-      final String disallowRemote = System
-              .getProperty(DISALLOW_REMOTE_CONTEXT_LOADING);
-      if ("true".equalsIgnoreCase(disallowRemote)) {
-        throw new JsonLdError(JsonLdErrorCode.LOADING_REMOTE_CONTEXT_FAILED,
-                "Remote context loading has been disallowed (uri was " + uri + ")");
-      }
+    }
 
-      try {
-        Document remoteDocument = defaultLoader.loadDocument(uri, options);
-        documentCache.put(uri, remoteDocument);
-        return remoteDocument;
-      } catch (final Exception e) {
-        throw new JsonLdError(JsonLdErrorCode.LOADING_REMOTE_CONTEXT_FAILED, uri + " " + e.getMessage());
-      }
+    final String disallowRemote = System.getProperty(DISALLOW_REMOTE_CONTEXT_LOADING);
+    if ("true".equalsIgnoreCase(disallowRemote)) {
+      throw new JsonLdError(
+          JsonLdErrorCode.LOADING_REMOTE_CONTEXT_FAILED,
+          "Remote context loading has been disallowed (uri was " + uri + ")");
+    }
+
+    try {
+      Document remoteDocument = DEFAULT_LOADER.loadDocument(uri, options);
+      documentCache.put(uri, remoteDocument);
+      return remoteDocument;
+    } catch (final Exception e) {
+      throw new JsonLdError(JsonLdErrorCode.LOADING_REMOTE_CONTEXT_FAILED, uri + " " + e.getMessage());
     }
   }
 

--- a/src/main/java/com/ontotext/trree/plugin/mongodb/MongoResultIterator.java
+++ b/src/main/java/com/ontotext/trree/plugin/mongodb/MongoResultIterator.java
@@ -22,6 +22,7 @@ import org.bson.Document;
 import org.bson.codecs.DocumentCodec;
 import org.bson.json.JsonMode;
 import org.bson.json.JsonWriterSettings;
+import org.eclipse.collections.api.iterator.LongIterator;
 import org.eclipse.rdf4j.model.*;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.rio.*;
@@ -36,6 +37,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.net.URI;
 import java.util.*;
+import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 public class MongoResultIterator extends StatementIterator {
@@ -45,20 +47,20 @@ public class MongoResultIterator extends StatementIterator {
 	private String query, projection, hint, database, collection;
 	private Collation collation;
 	private List<Document> aggregation = null;
-	private long searchSubject;
+	protected long searchSubject;
 	// custom graph id, if not present should equal to indexId
 	private long graphId;
 	// the id of the index, could be shared among multiple iterators
 	private long indexId;
-	private boolean initialized = false;
-	private boolean initializedByEntityIterator = false;
+	protected boolean initialized = false;
+	protected boolean initializedByEntityIterator = false;
 	private boolean searchDone = false;
 	private MongoClient client;
 	private MongoDatabase db;
 	private MongoCollection<Document> coll;
-	private MongoCursor<Document> iter;
-	private Model currentRDF;
-	private Entities entities;
+	protected MongoCursor<Document> iter;
+	protected Model currentRDF;
+	protected Entities entities;
 	private MongoDBPlugin plugin;
 	private RequestCache cache;
 
@@ -69,7 +71,7 @@ public class MongoResultIterator extends StatementIterator {
 	private boolean cloned = false;
 	private boolean entityIteratorCreated = false;
 	private boolean modelIteratorCreated = false;
-	private boolean interrupted = false;
+	protected boolean interrupted = false;
 	private boolean closed = false;
 	// if some of the query components are constructed with a function
 	// and set using bind the first time they are visited will be null. If we have setter with null
@@ -77,6 +79,12 @@ public class MongoResultIterator extends StatementIterator {
 	// this property prevents the iterator to be closed the first time if any of the
 	// set components are null (query, hint, projection, collation, aggregation)
 	private boolean closeable = true;
+
+	private boolean batched = false;
+	private boolean batchedLoading = false;
+	private int documentsLimit;
+	private BatchDocumentStore batchDocumentStore;
+	private LongIterator storeIterator;
 
 	public MongoResultIterator(MongoDBPlugin plugin, MongoClient client, String database, String collection, RequestCache cache, long searchsubject) {
 		this.cache = cache;
@@ -156,7 +164,31 @@ public class MongoResultIterator extends StatementIterator {
 			plugin.getLogger().error("Could not connect to mongo", ex);
 			throw new PluginException("Could not connect to MongoDB. Please make sure you are using correct authentication. " + ex.getMessage());
 		}
+		if (batched) {
+			if (iter != null && iter.hasNext()) {
+				batchDocumentStore = new BatchDocumentStore();
+				loadBatchedData();
+				storeIterator = batchDocumentStore.getIterator();
+				this.currentRDF = batchDocumentStore.getData();
+			}
+			return batchDocumentStore.size() > 0;
+		}
 		return iter != null && iter.hasNext();
+	}
+
+	private void loadBatchedData() {
+		Model[] data = new Model[1];
+		batchedLoading = true;
+		try {
+			while (hasSolution() && batchDocumentStore.size() <= getDocumentsLimit()) {
+				long docId = readNextDocument(current -> data[0] = current);
+				if (docId != 0) {
+					batchDocumentStore.addDocument(docId, data[0]);
+				}
+			}
+		} finally {
+			batchedLoading = false;
+		}
 	}
 
 	@Override
@@ -184,6 +216,11 @@ public class MongoResultIterator extends StatementIterator {
 		initializedByEntityIterator = false;
 
 		IOUtils.closeQuietly((Closeable) jsonLdParserConfig.get(JSONLDSettings.DOCUMENT_LOADER));
+
+		if (batchDocumentStore != null) {
+			batchDocumentStore.clear();
+			batchDocumentStore = null;
+		}
 	}
 
 	public void setQuery(String query) {
@@ -228,12 +265,24 @@ public class MongoResultIterator extends StatementIterator {
 		};
 	}
 
-	private void advance() {
+	protected void advance() {
+		if (batched) {
+			this.object = storeIterator.next();
+		} else {
+			long id = readNextDocument(doc -> currentRDF = doc);
+			if (id > 0) {
+				object = id;
+			}
+		}
+	}
+
+	protected long readNextDocument(Consumer<Model> dataAccumulator) {
 		Document doc = iter.next();
 
-		if (interrupted)
-			return;
-
+		if (interrupted) {
+			return 0;
+		}
+		
 		String entity = null;
 		if (doc.containsKey(GRAPH)) {
 			Object item = doc.get(GRAPH);
@@ -326,17 +375,18 @@ public class MongoResultIterator extends StatementIterator {
 			if (id == 0) {
 				id = entities.put(v, Scope.REQUEST);
 			}
-			this.object = id;
-
 			Object customNode = doc.get(CUSTOM_NODE);
 			if (customNode instanceof Document) {
 				for (Map.Entry<String, Object> val : ((Document) customNode).entrySet()) {
 					currentRDF.add(v, plugin.vf.createIRI(MongoDBPlugin.NAMESPACE_INST, val.getKey()), plugin.vf.createLiteral(val.getValue().toString()));
 				}
 			}
+			dataAccumulator.accept(currentRDF);
+			return id;
 		} catch (RDFParseException | UnsupportedRDFormatException | IOException e) {
 			iter.close();
 			plugin.getLogger().error("Could not parse mongo document", e);
+			return 0;
 		}
 	}
 
@@ -408,6 +458,9 @@ public class MongoResultIterator extends StatementIterator {
 	}
 
 	protected boolean hasSolution() {
+		if (batched && !batchedLoading) {
+			return !interrupted && storeIterator != null && storeIterator.hasNext();
+		}
 		return !interrupted && iter != null && iter.hasNext();
 	}
 
@@ -515,6 +568,17 @@ public class MongoResultIterator extends StatementIterator {
 
 	public void setIndexId(long indexId) {
 		this.indexId = indexId;
+	}
+
+	public void setDocumentsLimit(int documentsLimit) {
+		if (documentsLimit > 0) {
+			batched = true;
+		}
+		this.documentsLimit = documentsLimit;
+	}
+
+	public int getDocumentsLimit() {
+		return documentsLimit;
 	}
 
 	public long getSearchSubject() {
@@ -642,6 +706,9 @@ public class MongoResultIterator extends StatementIterator {
 		hint = null;
 		modelIteratorCreated = false;
 		entityIteratorCreated = false;
+		if (batched) {
+			batchDocumentStore.clear();
+		}
 	}
 
 	public boolean isCloned() {

--- a/src/main/java/com/ontotext/trree/plugin/mongodb/MongoResultIterator.java
+++ b/src/main/java/com/ontotext/trree/plugin/mongodb/MongoResultIterator.java
@@ -273,12 +273,9 @@ public class MongoResultIterator extends StatementIterator {
 
 	protected void advance() {
 		if (batched) {
-			this.object = storeIterator.next();
+			object = storeIterator.next();
 		} else {
-			long id = readNextDocument(doc -> currentRDF = doc);
-			if (id > 0) {
-				object = id;
-			}
+			object = readNextDocument(doc -> currentRDF = doc);
 		}
 	}
 

--- a/src/test/java/com/ontotext/trree/plugin/mongodb/AbstractMongoBasicTest.java
+++ b/src/test/java/com/ontotext/trree/plugin/mongodb/AbstractMongoBasicTest.java
@@ -277,6 +277,9 @@ public abstract class AbstractMongoBasicTest extends AbstractMongoTest {
 			for (Document doc : documents) {
 				ObjectId id = doc.getObjectId("_id");
 				List<Map<String, Object>> graph = (List<Map<String, Object>>) doc.get("@graph");
+				if (graph == null) {
+					continue;
+				}
 
 				for (Map.Entry currentValue : graph.get(0).entrySet()) {
 					Object object = graph.get(0).get(currentValue.getKey());

--- a/src/test/java/com/ontotext/trree/plugin/mongodb/TestPluginMongoBasicQueries.java
+++ b/src/test/java/com/ontotext/trree/plugin/mongodb/TestPluginMongoBasicQueries.java
@@ -85,11 +85,11 @@ public class TestPluginMongoBasicQueries extends AbstractMongoBasicTest {
 
 	@Test
 	public void testAggregation() throws Exception {
-		query = "PREFIX : <http://www.ontotext.com/connectors/mongodb#>\r\n" +
-				"PREFIX inst: <http://www.ontotext.com/connectors/mongodb/instance#>\r\n" +
-				"select distinct ?entity {\n"
+		query = "PREFIX : <http://www.ontotext.com/connectors/mongodb#>\r\n"
+	            + "PREFIX inst: <http://www.ontotext.com/connectors/mongodb/instance#>\r\n"
+		        + "select distinct ?entity {\n"
 				+ "\t?search a inst:spb100 ;\n"
-				+ "\t:aggregate \"[{'$match': {}}, {'$sort': {'@id': 1}}, {'$limit': 2}]\" ;"
+				+ "\t:aggregate \"[{'$match': {}}, {'$sort': {'@id': 1}}, {'$limit': 2}]\" ;\n"
 				+ "\t:entity ?entity .\n"
 				+ "\tgraph inst:spb100 {\n"
 				+ "\t\t?s ?p ?o .\n"

--- a/src/test/java/com/ontotext/trree/plugin/mongodb/TestPluginMongoBatchedQueries.java
+++ b/src/test/java/com/ontotext/trree/plugin/mongodb/TestPluginMongoBatchedQueries.java
@@ -6,39 +6,44 @@ import org.junit.Test;
 
 public class TestPluginMongoBatchedQueries extends AbstractMongoBasicTest {
 
-	@Override
-	protected void loadData() {
-		loadFilesToMongo();
-		addMongoDates();
-	}
+  @Override
+  protected void loadData() {
+    loadFilesToMongo();
+    addMongoDates();
+  }
 
-	@Test
-	public void testResultsAreJoined() throws Exception {
-		query = "PREFIX mongodb-index: <http://www.ontotext.com/connectors/mongodb/instance#>\n"
-            + "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n"
-            + "PREFIX mongodb: <http://www.ontotext.com/connectors/mongodb#>\n"
-            + "PREFIX skos:  <http://www.w3.org/2004/02/skos/core#>\n"
-            + "PREFIX atlas: <https://id.roche.com/am/sc/at/>\n"
-            + "PREFIX prov: <http://www.w3.org/ns/prov#>\n"
-            + "PREFIX dct: <http://purl.org/dc/terms/>\n"
-            + "SELECT distinct * WHERE {\n"
-            + "    \n"
-            + "    {\n"
-            + "        [] a mongodb-index:spb100 ;\n"
-            + "        mongodb:batchSize 100 ;\n"
-            + "        mongodb:find '{}' ;\n"
-            + "        mongodb:entity [] .   \n"
-            + "\n"
-            + "        GRAPH mongodb-index:spb100 {\n"
-            + "            ?study skos:prefLabel ?st_label .\n"
-            + "            ?study prov:hadPrimarySource ?cr_study .\n"
-            + "            ?study ^dct:isPartOf ?act .\n"
-            + "        }\n"
-            + "    }    \n"
-            + "}";
+  @Override
+  protected RepositoryConfig createRepositoryConfiguration() {
+    return StandardUtils.createOwlimSe("empty");
+  }
 
-		verifyUnorderedResult();
-	}
+  @Test
+  public void testResultsAreJoined() throws Exception {
+    query = "PREFIX mongodb-index: <http://www.ontotext.com/connectors/mongodb/instance#>\n"
+        + "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n"
+        + "PREFIX mongodb: <http://www.ontotext.com/connectors/mongodb#>\n"
+        + "PREFIX skos:  <http://www.w3.org/2004/02/skos/core#>\n"
+        + "PREFIX atlas: <https://id.roche.com/am/sc/at/>\n"
+        + "PREFIX prov: <http://www.w3.org/ns/prov#>\n"
+        + "PREFIX dct: <http://purl.org/dc/terms/>\n"
+        + "SELECT distinct * WHERE {\n"
+        + "    \n"
+        + "    {\n"
+        + "        [] a mongodb-index:spb100 ;\n"
+        + "        mongodb:batchSize 100 ;\n"
+        + "        mongodb:find '{}' ;\n"
+        + "        mongodb:entity [] .   \n"
+        + "\n"
+        + "        GRAPH mongodb-index:spb100 {\n"
+        + "            ?study skos:prefLabel ?st_label .\n"
+        + "            ?study prov:hadPrimarySource ?cr_study .\n"
+        + "            ?study ^dct:isPartOf ?act .\n"
+        + "        }\n"
+        + "    }    \n"
+        + "}";
+
+    verifyUnorderedResult();
+  }
 
   /**
    * Test the lazy version of the batch definition.
@@ -46,27 +51,27 @@ public class TestPluginMongoBatchedQueries extends AbstractMongoBasicTest {
   @Test
   public void testResultsAreJoined_inverseDef() throws Exception {
     query = "PREFIX mongodb-index: <http://www.ontotext.com/connectors/mongodb/instance#>\n"
-            + "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n"
-            + "PREFIX mongodb: <http://www.ontotext.com/connectors/mongodb#>\n"
-            + "PREFIX skos:  <http://www.w3.org/2004/02/skos/core#>\n"
-            + "PREFIX atlas: <https://id.roche.com/am/sc/at/>\n"
-            + "PREFIX prov: <http://www.w3.org/ns/prov#>\n"
-            + "PREFIX dct: <http://purl.org/dc/terms/>\n"
-            + "SELECT distinct * WHERE {\n"
-            + "    \n"
-            + "    {\n"
-            + "        GRAPH mongodb-index:spb100 {\n"
-            + "            ?study skos:prefLabel ?st_label .\n"
-            + "            ?study prov:hadPrimarySource ?cr_study .\n"
-            + "            ?study ^dct:isPartOf ?act .\n"
-            + "        }\n"
-            + "\n"
-            + "        [] a mongodb-index:spb100 ;\n"
-            + "        mongodb:batchSize 100 ;\n"
-            + "        mongodb:find '{}' ;\n"
-            + "        mongodb:entity [] .   \n"
-            + "    }    \n"
-            + "}";
+        + "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n"
+        + "PREFIX mongodb: <http://www.ontotext.com/connectors/mongodb#>\n"
+        + "PREFIX skos:  <http://www.w3.org/2004/02/skos/core#>\n"
+        + "PREFIX atlas: <https://id.roche.com/am/sc/at/>\n"
+        + "PREFIX prov: <http://www.w3.org/ns/prov#>\n"
+        + "PREFIX dct: <http://purl.org/dc/terms/>\n"
+        + "SELECT distinct * WHERE {\n"
+        + "    \n"
+        + "    {\n"
+        + "        GRAPH mongodb-index:spb100 {\n"
+        + "            ?study skos:prefLabel ?st_label .\n"
+        + "            ?study prov:hadPrimarySource ?cr_study .\n"
+        + "            ?study ^dct:isPartOf ?act .\n"
+        + "        }\n"
+        + "\n"
+        + "        [] a mongodb-index:spb100 ;\n"
+        + "        mongodb:batchSize 100 ;\n"
+        + "        mongodb:find '{}' ;\n"
+        + "        mongodb:entity [] .   \n"
+        + "    }    \n"
+        + "}";
 
     verifyUnorderedResult();
   }
@@ -74,39 +79,56 @@ public class TestPluginMongoBatchedQueries extends AbstractMongoBasicTest {
   @Test
   public void testBadConfig() throws Exception {
     query = "PREFIX mongodb-index: <http://www.ontotext.com/connectors/mongodb/instance#>\n"
-            + "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n"
-            + "PREFIX mongodb: <http://www.ontotext.com/connectors/mongodb#>\n"
-            + "PREFIX skos:  <http://www.w3.org/2004/02/skos/core#>\n"
-            + "PREFIX atlas: <https://id.roche.com/am/sc/at/>\n"
-            + "PREFIX prov: <http://www.w3.org/ns/prov#>\n"
-            + "PREFIX dct: <http://purl.org/dc/terms/>\n"
-            + "SELECT distinct * WHERE {\n"
-            + "    \n"
-            + "    {\n"
-            + "        [] a mongodb-index:spb100 ;\n"
-            + "        mongodb:batchSize \"-1\" ;\n"
-            + "        mongodb:find '{}' ;\n"
-            + "        mongodb:entity [] .   \n"
-            + "\n"
-            + "        GRAPH mongodb-index:spb100 {\n"
-            + "            ?study skos:prefLabel ?st_label .\n"
-            + "            ?study prov:hadPrimarySource ?cr_study .\n"
-            + "            ?study ^dct:isPartOf ?act .\n"
-            + "        }\n"
-            + "    }    \n"
-            + "}";
+        + "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n"
+        + "PREFIX mongodb: <http://www.ontotext.com/connectors/mongodb#>\n"
+        + "PREFIX skos:  <http://www.w3.org/2004/02/skos/core#>\n"
+        + "PREFIX atlas: <https://id.roche.com/am/sc/at/>\n"
+        + "PREFIX prov: <http://www.w3.org/ns/prov#>\n"
+        + "PREFIX dct: <http://purl.org/dc/terms/>\n"
+        + "SELECT distinct * WHERE {\n"
+        + "    \n"
+        + "    {\n"
+        + "        [] a mongodb-index:spb100 ;\n"
+        + "        mongodb:batchSize \"-1\" ;\n"
+        + "        mongodb:find '{}' ;\n"
+        + "        mongodb:entity [] .   \n"
+        + "\n"
+        + "        GRAPH mongodb-index:spb100 {\n"
+        + "            ?study skos:prefLabel ?st_label .\n"
+        + "            ?study prov:hadPrimarySource ?cr_study .\n"
+        + "            ?study ^dct:isPartOf ?act .\n"
+        + "        }\n"
+        + "" + "    }    \n"
+        + "}";
 
     verifyUnorderedResult();
   }
 
-	@Override
-	protected boolean isLearnMode() {
-		return false;
-	}
+  @Test
+  public void testClientExactCase() throws Exception {
+    query = "PREFIX mongodb-index: <http://www.ontotext.com/connectors/mongodb/instance#>\n"
+        + "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n"
+        + "PREFIX mongodb: <http://www.ontotext.com/connectors/mongodb#>\n"
+        + "PREFIX skos:  <http://www.w3.org/2004/02/skos/core#>\n"
+        + "PREFIX atlas: <https://id.roche.com/am/sc/at/>\n"
+        + "PREFIX prov: <http://www.w3.org/ns/prov#>\n"
+        + "PREFIX dct: <http://purl.org/dc/terms/>\n"
+        + "SELECT distinct * WHERE {\n"
+        + "    \n"
+        + "    {\n"
+        + "        [] a mongodb-index:spb100 ;\n"
+        + "        mongodb:batchSize 100 ;\n"
+        + "        mongodb:find '{}' ;\n"
+        + "        mongodb:entity [] .   \n"
+        + "\n"
+        + "        GRAPH mongodb-index:spb100 {\n"
+        + "            values ?cr_study { <https://id.roche.com/am/a3/jkmxqmxfd296b3k8f6sztmsd67kt> } \n"
+        + "            ?study prov:hadPrimarySource ?cr_study .\n"
+        + "            ?study ^dct:isPartOf ?act .\n"
+        + "        }\n"
+        + "    }    \n"
+        + "}";
 
-	@Override
-	protected RepositoryConfig createRepositoryConfiguration() {
-		return StandardUtils.createOwlimSe("empty");
-	}
-
+    verifyUnorderedResult();
+  }
 }

--- a/src/test/java/com/ontotext/trree/plugin/mongodb/TestPluginMongoBatchedQueries.java
+++ b/src/test/java/com/ontotext/trree/plugin/mongodb/TestPluginMongoBatchedQueries.java
@@ -1,0 +1,112 @@
+package com.ontotext.trree.plugin.mongodb;
+
+import com.ontotext.test.utils.StandardUtils;
+import org.eclipse.rdf4j.repository.config.RepositoryConfig;
+import org.junit.Test;
+
+public class TestPluginMongoBatchedQueries extends AbstractMongoBasicTest {
+
+	@Override
+	protected void loadData() {
+		loadFilesToMongo();
+		addMongoDates();
+	}
+
+	@Test
+	public void testResultsAreJoined() throws Exception {
+		query = "PREFIX mongodb-index: <http://www.ontotext.com/connectors/mongodb/instance#>\n"
+            + "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n"
+            + "PREFIX mongodb: <http://www.ontotext.com/connectors/mongodb#>\n"
+            + "PREFIX skos:  <http://www.w3.org/2004/02/skos/core#>\n"
+            + "PREFIX atlas: <https://id.roche.com/am/sc/at/>\n"
+            + "PREFIX prov: <http://www.w3.org/ns/prov#>\n"
+            + "PREFIX dct: <http://purl.org/dc/terms/>\n"
+            + "SELECT distinct * WHERE {\n"
+            + "    \n"
+            + "    {\n"
+            + "        [] a mongodb-index:spb100 ;\n"
+            + "        mongodb:batchSize 100 ;\n"
+            + "        mongodb:find '{}' ;\n"
+            + "        mongodb:entity [] .   \n"
+            + "\n"
+            + "        GRAPH mongodb-index:spb100 {\n"
+            + "            ?study skos:prefLabel ?st_label .\n"
+            + "            ?study prov:hadPrimarySource ?cr_study .\n"
+            + "            ?study ^dct:isPartOf ?act .\n"
+            + "        }\n"
+            + "    }    \n"
+            + "}";
+
+		verifyUnorderedResult();
+	}
+
+  /**
+   * Test the lazy version of the batch definition.
+   */
+  @Test
+  public void testResultsAreJoined_inverseDef() throws Exception {
+    query = "PREFIX mongodb-index: <http://www.ontotext.com/connectors/mongodb/instance#>\n"
+            + "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n"
+            + "PREFIX mongodb: <http://www.ontotext.com/connectors/mongodb#>\n"
+            + "PREFIX skos:  <http://www.w3.org/2004/02/skos/core#>\n"
+            + "PREFIX atlas: <https://id.roche.com/am/sc/at/>\n"
+            + "PREFIX prov: <http://www.w3.org/ns/prov#>\n"
+            + "PREFIX dct: <http://purl.org/dc/terms/>\n"
+            + "SELECT distinct * WHERE {\n"
+            + "    \n"
+            + "    {\n"
+            + "        GRAPH mongodb-index:spb100 {\n"
+            + "            ?study skos:prefLabel ?st_label .\n"
+            + "            ?study prov:hadPrimarySource ?cr_study .\n"
+            + "            ?study ^dct:isPartOf ?act .\n"
+            + "        }\n"
+            + "\n"
+            + "        [] a mongodb-index:spb100 ;\n"
+            + "        mongodb:batchSize 100 ;\n"
+            + "        mongodb:find '{}' ;\n"
+            + "        mongodb:entity [] .   \n"
+            + "    }    \n"
+            + "}";
+
+    verifyUnorderedResult();
+  }
+
+  @Test
+  public void testBadConfig() throws Exception {
+    query = "PREFIX mongodb-index: <http://www.ontotext.com/connectors/mongodb/instance#>\n"
+            + "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n"
+            + "PREFIX mongodb: <http://www.ontotext.com/connectors/mongodb#>\n"
+            + "PREFIX skos:  <http://www.w3.org/2004/02/skos/core#>\n"
+            + "PREFIX atlas: <https://id.roche.com/am/sc/at/>\n"
+            + "PREFIX prov: <http://www.w3.org/ns/prov#>\n"
+            + "PREFIX dct: <http://purl.org/dc/terms/>\n"
+            + "SELECT distinct * WHERE {\n"
+            + "    \n"
+            + "    {\n"
+            + "        [] a mongodb-index:spb100 ;\n"
+            + "        mongodb:batchSize \"-1\" ;\n"
+            + "        mongodb:find '{}' ;\n"
+            + "        mongodb:entity [] .   \n"
+            + "\n"
+            + "        GRAPH mongodb-index:spb100 {\n"
+            + "            ?study skos:prefLabel ?st_label .\n"
+            + "            ?study prov:hadPrimarySource ?cr_study .\n"
+            + "            ?study ^dct:isPartOf ?act .\n"
+            + "        }\n"
+            + "    }    \n"
+            + "}";
+
+    verifyUnorderedResult();
+  }
+
+	@Override
+	protected boolean isLearnMode() {
+		return false;
+	}
+
+	@Override
+	protected RepositoryConfig createRepositoryConfiguration() {
+		return StandardUtils.createOwlimSe("empty");
+	}
+
+}

--- a/src/test/java/com/ontotext/trree/plugin/mongodb/TestPluginMongoCollationQueries.java
+++ b/src/test/java/com/ontotext/trree/plugin/mongodb/TestPluginMongoCollationQueries.java
@@ -1,14 +1,10 @@
 package com.ontotext.trree.plugin.mongodb;
 
-import java.util.Arrays;
-import java.util.List;
-
-import org.eclipse.rdf4j.repository.config.RepositoryConfig;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import com.ontotext.test.utils.StandardUtils;
-
-import static org.junit.Assert.assertEquals;
+import org.eclipse.rdf4j.repository.config.RepositoryConfig;
+import org.junit.Test;
 
 public class TestPluginMongoCollationQueries extends AbstractMongoBasicTest {
 

--- a/src/test/java/com/ontotext/trree/plugin/mongodb/TestPluginMongoExtended.java
+++ b/src/test/java/com/ontotext/trree/plugin/mongodb/TestPluginMongoExtended.java
@@ -17,12 +17,11 @@ public class TestPluginMongoExtended extends AbstractMongoBasicTest {
 	 */
 	@Test
 	public void testJsonLdWithAndWithoutContexts() {
-
-		String query = "PREFIX : <http://www.ontotext.com/connectors/mongodb#>\r\n" +
-				"PREFIX inst: <http://www.ontotext.com/connectors/mongodb/instance#>\r\n" +
-				"select distinct ?entity {\n"
+		String query = "PREFIX : <http://www.ontotext.com/connectors/mongodb#>\r\n"
+		        + "PREFIX inst: <http://www.ontotext.com/connectors/mongodb/instance#>\r\n"
+		        + "select distinct ?entity {\n"
 				+ "\t?search a inst:spb100 ;\n"
-				+ "\t:find \"{}\" ;"
+				+ "\t:find \"{}\" ;\n"
 				+ "\t:entity ?entity .\n"
 				+ "\tgraph inst:spb100 {\n"
 				+ "\t\t?s ?p ?o .\n"

--- a/src/test/resources/mongodb/input/TestPluginMongoBatchedQueries/file1.jsonld
+++ b/src/test/resources/mongodb/input/TestPluginMongoBatchedQueries/file1.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@base": "https://id.roche.com/am/a6/",
+    "@vocab": "https://id.roche.com/am/sc/at/",
+    "dct": "http://purl.org/dc/terms/",
+    "prov": "http://www.w3.org/ns/prov#",
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "type": "@type",
+    "_id": "@nest",
+    "relationship_entity": "dct:isPartOf",
+    "name": "skos:prefLabel",
+    "created_by": "dct:creator",
+    "coralreef_uri": {
+      "@type": "@id",
+      "@id": "prov:hadPrimarySource"
+    }
+  },
+  "name": "YO42311",
+  "type": "Study",
+  "@id": "6568f1aebd1e4f12a0c3d9a1",
+  "coralreef_uri": "https://id.roche.com/am/a3/jkmxqmxfd296b3k8f6sztmsd67kt"
+}

--- a/src/test/resources/mongodb/input/TestPluginMongoBatchedQueries/file2.jsonld
+++ b/src/test/resources/mongodb/input/TestPluginMongoBatchedQueries/file2.jsonld
@@ -1,0 +1,27 @@
+{
+  "@context": {
+    "@base": "https://id.roche.com/am/a6/",
+    "@vocab": "https://id.roche.com/am/sc/at/",
+    "dct": "http://purl.org/dc/terms/",
+    "prov": "http://www.w3.org/ns/prov#",
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "type": "@type",
+    "_id": "@nest",
+    "relationship_entity": "dct:isPartOf",
+    "name": "skos:prefLabel",
+    "created_by": "dct:creator",
+    "coralreef_uri": {
+      "@type": "@id",
+      "@id": "prov:hadPrimarySource"
+    }
+  },
+  "name": "CSRFinal_ADS",
+  "type": "Activity",
+  "@id": "6568f1aebf5d4e12c7d3e8b3",
+  "relationship_entity": {
+    "@id": "6568f1aebd1e4f12a0c3d9a1",
+    "type": "Study",
+    "name": "YO42311"
+  },
+  "coralreef_uri": "https://id.roche.com/am/a3/ng987gby2hn32z69746x"
+}

--- a/src/test/resources/mongodb/input/TestPluginMongoBatchedQueries/file3.jsonld
+++ b/src/test/resources/mongodb/input/TestPluginMongoBatchedQueries/file3.jsonld
@@ -1,0 +1,27 @@
+{
+  "@context": {
+    "@base": "https://id.roche.com/am/a6/",
+    "@vocab": "https://id.roche.com/am/sc/at/",
+    "dct": "http://purl.org/dc/terms/",
+    "prov": "http://www.w3.org/ns/prov#",
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "type": "@type",
+    "_id": "@nest",
+    "relationship_entity": "dct:isPartOf",
+    "name": "skos:prefLabel",
+    "created_by": "dct:creator",
+    "coralreef_uri": {
+      "@type": "@id",
+      "@id": "prov:hadPrimarySource"
+    }
+  },
+  "name": "CSRUpdate_SDTMv_dp",
+  "type": "Activity",
+  "@id": "6568f1aecb2e4f12d9e3c7b4",
+  "relationship_entity": {
+    "@id": "6568f1aebd1e4f12a0c3d9a1",
+    "type": "Study",
+    "name": "YO42311"
+  },
+  "coralreef_uri": "https://id.roche.com/am/a3/ng4gskyq7qp7c9g4pg8s"
+}

--- a/src/test/resources/mongodb/results/TestPluginMongoBasicQueries/shouldWorkWithUNION_customGraphs_example_2
+++ b/src/test/resources/mongodb/results/TestPluginMongoBasicQueries/shouldWorkWithUNION_customGraphs_example_2
@@ -1,0 +1,2 @@
+[s1=http://www.bbc.co.uk/things/1646461#id;o1=http://www.bbc.co.uk/ontologies/creativework/BlogPost]
+[s2=http://www.bbc.co.uk/things/1646453#id;o2=http://www.bbc.co.uk/ontologies/creativework/BlogPost]

--- a/src/test/resources/mongodb/results/TestPluginMongoBatchedQueries/testClientExactCase
+++ b/src/test/resources/mongodb/results/TestPluginMongoBatchedQueries/testClientExactCase
@@ -1,0 +1,2 @@
+[cr_study=https://id.roche.com/am/a3/jkmxqmxfd296b3k8f6sztmsd67kt;study=https://id.roche.com/am/a6/6568f1aebd1e4f12a0c3d9a1;act=https://id.roche.com/am/a6/6568f1aebf5d4e12c7d3e8b3]
+[cr_study=https://id.roche.com/am/a3/jkmxqmxfd296b3k8f6sztmsd67kt;study=https://id.roche.com/am/a6/6568f1aebd1e4f12a0c3d9a1;act=https://id.roche.com/am/a6/6568f1aecb2e4f12d9e3c7b4]

--- a/src/test/resources/mongodb/results/TestPluginMongoBatchedQueries/testResultsAreJoined
+++ b/src/test/resources/mongodb/results/TestPluginMongoBatchedQueries/testResultsAreJoined
@@ -1,0 +1,2 @@
+[study=https://id.roche.com/am/a6/6568f1aebd1e4f12a0c3d9a1;st_label="YO42311";cr_study=https://id.roche.com/am/a3/jkmxqmxfd296b3k8f6sztmsd67kt;act=https://id.roche.com/am/a6/6568f1aebf5d4e12c7d3e8b3]
+[study=https://id.roche.com/am/a6/6568f1aebd1e4f12a0c3d9a1;st_label="YO42311";cr_study=https://id.roche.com/am/a3/jkmxqmxfd296b3k8f6sztmsd67kt;act=https://id.roche.com/am/a6/6568f1aecb2e4f12d9e3c7b4]

--- a/src/test/resources/mongodb/results/TestPluginMongoBatchedQueries/testResultsAreJoined_inverseDef
+++ b/src/test/resources/mongodb/results/TestPluginMongoBatchedQueries/testResultsAreJoined_inverseDef
@@ -1,0 +1,2 @@
+[study=https://id.roche.com/am/a6/6568f1aebd1e4f12a0c3d9a1;st_label="YO42311";cr_study=https://id.roche.com/am/a3/jkmxqmxfd296b3k8f6sztmsd67kt;act=https://id.roche.com/am/a6/6568f1aebf5d4e12c7d3e8b3]
+[study=https://id.roche.com/am/a6/6568f1aebd1e4f12a0c3d9a1;st_label="YO42311";cr_study=https://id.roche.com/am/a3/jkmxqmxfd296b3k8f6sztmsd67kt;act=https://id.roche.com/am/a6/6568f1aecb2e4f12d9e3c7b4]


### PR DESCRIPTION
Added functionality where all documents matching the input query, up to a maximum are loaded in memory and returned as named graph collection instead of processing one by one.
When the new functionality is used the plugin is no longer streaming but will require a buffer to store the documents until the query is complete.

Added system property configuration that controls the maximum allowed batch size: graphdb.mongodb.maxBatchSize. This is to prevent OOM problems.