### PR TITLE
Change JSONLD library to GraphDB Jsonld implementation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 	<description>MongoDB plugin for GraphDB</description>
 
 	<properties>
-		<graphdb.version>11.0.0-TR18</graphdb.version>
+		<graphdb.version>11.0.0-RC3</graphdb.version>
 		<dependency.check.version>12.1.0</dependency.check.version>
 
 		<java.level>1.8</java.level>
@@ -124,13 +124,18 @@
 			<groupId>com.ontotext.graphdb</groupId>
 			<artifactId>graphdb-sdk</artifactId>
 			<version>${graphdb.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.eclipse.rdf4j</groupId>
+					<artifactId>rdf4j-rio-jsonld</artifactId>
+				</exclusion>
+			</exclusions>
 			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>com.ontotext.graphdb</groupId>
 			<artifactId>graphdb-runtime</artifactId>
-			<scope>test</scope>
 			<version>${graphdb.version}</version>
 			<!-- Temporary workaround for missing Ontop dependencies for Ontotext build of Ontop -->
 			<exclusions>
@@ -139,6 +144,7 @@
 					<artifactId>*</artifactId>
 				</exclusion>
 			</exclusions>
+			<scope>provided</scope>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/com/ontotext/trree/plugin/mongodb/CachingDocumentLoader.java
+++ b/src/main/java/com/ontotext/trree/plugin/mongodb/CachingDocumentLoader.java
@@ -1,11 +1,11 @@
 package com.ontotext.trree.plugin.mongodb;
 
-import no.hasmac.jsonld.JsonLdError;
-import no.hasmac.jsonld.JsonLdErrorCode;
-import no.hasmac.jsonld.document.Document;
-import no.hasmac.jsonld.loader.DocumentLoader;
-import no.hasmac.jsonld.loader.DocumentLoaderOptions;
-import no.hasmac.jsonld.loader.SchemeRouter;
+import com.apicatalog.jsonld.JsonLdError;
+import com.apicatalog.jsonld.JsonLdErrorCode;
+import com.apicatalog.jsonld.document.Document;
+import com.apicatalog.jsonld.loader.DocumentLoader;
+import com.apicatalog.jsonld.loader.DocumentLoaderOptions;
+import com.apicatalog.jsonld.loader.SchemeRouter;
 
 import java.io.Closeable;
 import java.net.URI;

--- a/src/main/java/com/ontotext/trree/plugin/mongodb/MongoResultIterator.java
+++ b/src/main/java/com/ontotext/trree/plugin/mongodb/MongoResultIterator.java
@@ -1,10 +1,10 @@
 package com.ontotext.trree.plugin.mongodb;
 
-import static no.hasmac.jsonld.lang.Keywords.*;
+import static com.apicatalog.jsonld.lang.Keywords.*;
 
-import no.hasmac.jsonld.JsonLdError;
-import no.hasmac.jsonld.document.JsonDocument;
-import no.hasmac.jsonld.loader.DocumentLoaderOptions;
+import com.apicatalog.jsonld.JsonLdError;
+import com.apicatalog.jsonld.document.JsonDocument;
+import com.apicatalog.jsonld.loader.DocumentLoaderOptions;
 import com.mongodb.MongoSecurityException;
 import com.mongodb.client.*;
 import com.mongodb.client.model.Collation;
@@ -12,6 +12,8 @@ import com.mongodb.client.model.CollationAlternate;
 import com.mongodb.client.model.CollationCaseFirst;
 import com.mongodb.client.model.CollationMaxVariable;
 import com.mongodb.client.model.CollationStrength;
+import com.ontotext.rio.jsonld.GraphDBJSONLD11ParserFactory;
+import com.ontotext.rio.jsonld.settings.GraphDBJSONLDSettings;
 import com.ontotext.trree.sdk.Entities;
 import com.ontotext.trree.sdk.Entities.Scope;
 import com.ontotext.trree.sdk.PluginException;
@@ -29,7 +31,6 @@ import org.eclipse.rdf4j.rio.helpers.ParseErrorLogger;
 
 import jakarta.json.JsonString;
 import jakarta.json.JsonStructure;
-import org.eclipse.rdf4j.rio.jsonld.JSONLDSettings;
 
 import java.io.Closeable;
 import java.io.IOException;
@@ -78,6 +79,11 @@ public class MongoResultIterator extends StatementIterator {
 	// set components are null (query, hint, projection, collation, aggregation)
 	private boolean closeable = true;
 
+	static {
+		GraphDBJSONLD11ParserFactory jsonldFactory = new GraphDBJSONLD11ParserFactory();
+		RDFParserRegistry.getInstance().add(jsonldFactory);
+	}
+
 	public MongoResultIterator(MongoDBPlugin plugin, MongoClient client, String database, String collection, RequestCache cache, long searchsubject) {
 		this.cache = cache;
 		this.plugin = plugin;
@@ -90,7 +96,7 @@ public class MongoResultIterator extends StatementIterator {
 		// this way we would not accumulate a lot of documents over time
 		jsonLdParserConfig = new ParserConfig();
 		documentLoader = new CachingDocumentLoader();
-		jsonLdParserConfig.set(JSONLDSettings.DOCUMENT_LOADER, documentLoader);
+		jsonLdParserConfig.set(GraphDBJSONLDSettings.DOCUMENT_LOADER, documentLoader);
 	}
 
 	@Override
@@ -183,7 +189,7 @@ public class MongoResultIterator extends StatementIterator {
 		initialized = false;
 		initializedByEntityIterator = false;
 
-		IOUtils.closeQuietly((Closeable) jsonLdParserConfig.get(JSONLDSettings.DOCUMENT_LOADER));
+		IOUtils.closeQuietly((Closeable) jsonLdParserConfig.get(GraphDBJSONLDSettings.DOCUMENT_LOADER));
 	}
 
 	public void setQuery(String query) {


### PR DESCRIPTION
Changed graphdb-runtime to scope provided as GraphDB Jsonld got moved to graphdb-common

Changed from hasmac jsonld to GraphDB jsonld

Excluded rdf4j-rio-jsonld