### PR TITLE
GDB-11761 Adds option for batch processing of the result documents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 target
 *.iml
 .idea
+
+# Eclipse
+.classpath
+.project
+.settings/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+## 1.0.11
+
+- [GDB-11761](https://graphwise.atlassian.net/browse/GDB-11761): Adds batch processing of the result documents
+
+  Added functionality where all documents matching the input query, up to a maximum are loaded in memory and returned as
+  named graph collection instead of processing one by one.
+  When the new functionality is used the plugin is no longer streaming but will require a buffer to store the documents
+  until the query is complete.
+
+  Added system property configuration that controls the maximum allowed batch size: `graphdb.mongodb.maxBatchSize`. This
+  is to prevent Out-of-Memory problems.
+
+  Updated the version of the GraphDB SDK to `10.8.7` and the Java version to 11.
+
+## 1.0.x
+
+- Legacy versions. 

--- a/pom.xml
+++ b/pom.xml
@@ -4,15 +4,15 @@
 
 	<groupId>com.ontotext.graphdb.plugins</groupId>
 	<artifactId>mongodb-plugin</artifactId>
-	<version>1.0.10</version>
+	<version>1.0-SNAPSHOT</version>
 	<name>MongoDB Plugin</name>
 	<description>MongoDB plugin for GraphDB</description>
 
 	<properties>
-		<graphdb.version>10.1.0</graphdb.version>
+		<graphdb.version>10.8.7</graphdb.version>
 		<dependency.check.version>6.2.2</dependency.check.version>
 
-		<java.level>1.8</java.level>
+		<java.level>11</java.level>
 
 		<internal.repo>https://maven.ontotext.com/content/repositories/owlim-releases</internal.repo>
 		<snapshots.repo>https://maven.ontotext.com/content/repositories/owlim-snapshots</snapshots.repo>
@@ -127,6 +127,12 @@
 			<scope>provided</scope>
 		</dependency>
 
+    <dependency>
+      <groupId>org.eclipse.collections</groupId>
+      <artifactId>eclipse-collections-api</artifactId>
+      <version>11.1.0</version>
+    </dependency>
+
 		<dependency>
 			<groupId>com.ontotext.graphdb</groupId>
 			<artifactId>graphdb-runtime</artifactId>
@@ -237,7 +243,7 @@
 		<connection>scm:git:git@github.com:Ontotext-AD/graphdb-mongodb-plugin.git</connection>
 		<developerConnection>scm:git:git@github.com:Ontotext-AD/graphdb-mongodb-plugin.git</developerConnection>
 		<url>https://github.com/Ontotext-AD/graphdb-mongodb-plugin</url>
-		<tag>1.0.10</tag>
+		<tag>HEAD</tag>
 	</scm>
 
 </project>

--- a/src/main/java/com/ontotext/trree/plugin/mongodb/BatchDocumentStore.java
+++ b/src/main/java/com/ontotext/trree/plugin/mongodb/BatchDocumentStore.java
@@ -1,0 +1,40 @@
+package com.ontotext.trree.plugin.mongodb;
+
+import org.eclipse.collections.api.iterator.LongIterator;
+import org.eclipse.collections.api.set.primitive.MutableLongSet;
+import org.eclipse.collections.api.factory.primitive.LongSets;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.impl.LinkedHashModel;
+
+/**
+ * Collects the document data during batch processing.
+ *
+ * @author <a href="mailto:borislav.bonev@ontotext.com">Borislav Bonev</a>
+ * @since 26/03/2025
+ */
+public class BatchDocumentStore {
+	private final MutableLongSet documentIds = LongSets.mutable.empty();
+	private final Model data = new LinkedHashModel();
+
+	public void addDocument(long id, Model model) {
+		documentIds.add(id);
+		data.addAll(model);
+	}
+
+	public Model getData() {
+		return data;
+	}
+
+	public void clear() {
+		documentIds.clear();
+		data.clear();
+	}
+
+	public int size() {
+		return documentIds.size();
+	}
+
+	LongIterator getIterator() {
+		return documentIds.longIterator();
+	}
+}

--- a/src/main/java/com/ontotext/trree/plugin/mongodb/CachingDocumentLoader.java
+++ b/src/main/java/com/ontotext/trree/plugin/mongodb/CachingDocumentLoader.java
@@ -4,10 +4,8 @@ import com.github.jsonldjava.core.DocumentLoader;
 import com.github.jsonldjava.core.JsonLdError;
 import com.github.jsonldjava.core.RemoteDocument;
 import com.github.jsonldjava.utils.JsonUtils;
-
 import java.io.Closeable;
 import java.net.URL;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
 

--- a/src/main/java/com/ontotext/trree/plugin/mongodb/MongoResultIterator.java
+++ b/src/main/java/com/ontotext/trree/plugin/mongodb/MongoResultIterator.java
@@ -23,6 +23,7 @@ import org.bson.Document;
 import org.bson.codecs.DocumentCodec;
 import org.bson.json.JsonMode;
 import org.bson.json.JsonWriterSettings;
+import org.eclipse.collections.api.iterator.LongIterator;
 import org.eclipse.rdf4j.model.*;
 import org.eclipse.rdf4j.model.impl.SimpleValueFactory;
 import org.eclipse.rdf4j.rio.ParserConfig;
@@ -42,6 +43,10 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.net.URI;
+import java.util.*;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 public class MongoResultIterator extends StatementIterator {
 
@@ -50,20 +55,20 @@ public class MongoResultIterator extends StatementIterator {
 	private String query, projection, hint, database, collection;
 	private Collation collation;
 	private List<Document> aggregation = null;
-	private long searchSubject;
+	protected long searchSubject;
 	// custom graph id, if not present should equal to indexId
 	private long graphId;
 	// the id of the index, could be shared among multiple iterators
 	private long indexId;
-	private boolean initialized = false;
-	private boolean initializedByEntityIterator = false;
+	protected boolean initialized = false;
+	protected boolean initializedByEntityIterator = false;
 	private boolean searchDone = false;
 	private MongoClient client;
 	private MongoDatabase db;
 	private MongoCollection<Document> coll;
-	private MongoCursor<Document> iter;
-	private Model currentRDF;
-	private Entities entities;
+	protected MongoCursor<Document> iter;
+	protected Model currentRDF;
+	protected Entities entities;
 	private MongoDBPlugin plugin;
 	private RequestCache cache;
 
@@ -74,7 +79,7 @@ public class MongoResultIterator extends StatementIterator {
 	private boolean cloned = false;
 	private boolean entityIteratorCreated = false;
 	private boolean modelIteratorCreated = false;
-	private boolean interrupted = false;
+	protected boolean interrupted = false;
 	private boolean closed = false;
 	// if some of the query components are constructed with a function
 	// and set using bind the first time they are visited will be null. If we have setter with null
@@ -82,6 +87,12 @@ public class MongoResultIterator extends StatementIterator {
 	// this property prevents the iterator to be closed the first time if any of the
 	// set components are null (query, hint, projection, collation, aggregation)
 	private boolean closeable = true;
+
+	private boolean batched = false;
+	private boolean batchedLoading = false;
+	private int documentsLimit;
+	private BatchDocumentStore batchDocumentStore;
+	private LongIterator storeIterator;
 
 	public MongoResultIterator(MongoDBPlugin plugin, MongoClient client, String database, String collection, RequestCache cache, long searchsubject) {
 		this.cache = cache;
@@ -161,7 +172,31 @@ public class MongoResultIterator extends StatementIterator {
 			plugin.getLogger().error("Could not connect to mongo", ex);
 			throw new PluginException("Could not connect to MongoDB. Please make sure you are using correct authentication. " + ex.getMessage());
 		}
+		if (batched) {
+			if (iter != null && iter.hasNext()) {
+				batchDocumentStore = new BatchDocumentStore();
+				loadBatchedData();
+				storeIterator = batchDocumentStore.getIterator();
+				this.currentRDF = batchDocumentStore.getData();
+			}
+			return batchDocumentStore.size() > 0;
+		}
 		return iter != null && iter.hasNext();
+	}
+
+	private void loadBatchedData() {
+		Model[] data = new Model[1];
+		batchedLoading = true;
+		try {
+			while (hasSolution() && batchDocumentStore.size() <= getDocumentsLimit()) {
+				long docId = readNextDocument(current -> data[0] = current);
+				if (docId != 0) {
+					batchDocumentStore.addDocument(docId, data[0]);
+				}
+			}
+		} finally {
+			batchedLoading = false;
+		}
 	}
 
 	@Override
@@ -189,6 +224,11 @@ public class MongoResultIterator extends StatementIterator {
 		initializedByEntityIterator = false;
 
 		IOUtils.closeQuietly((Closeable) jsonLdParserConfig.get(JSONLDSettings.DOCUMENT_LOADER));
+
+		if (batchDocumentStore != null) {
+			batchDocumentStore.clear();
+			batchDocumentStore = null;
+		}
 	}
 
 	public void setQuery(String query) {
@@ -233,11 +273,20 @@ public class MongoResultIterator extends StatementIterator {
 		};
 	}
 
-	private void advance() {
+	protected void advance() {
+		if (batched) {
+			object = storeIterator.next();
+		} else {
+			object = readNextDocument(doc -> currentRDF = doc);
+		}
+	}
+
+	protected long readNextDocument(Consumer<Model> dataAccumulator) {
 		Document doc = iter.next();
 
-		if (interrupted)
-			return;
+		if (interrupted) {
+			return 0;
+		}
 		
 		String entity = null;
 		if (doc.containsKey(GRAPH)) {
@@ -331,17 +380,18 @@ public class MongoResultIterator extends StatementIterator {
 			if (id == 0) {
 				id = entities.put(v, Scope.REQUEST);
 			}
-			this.object = id;
-
 			Object customNode = doc.get(CUSTOM_NODE);
 			if (customNode instanceof Document) {
 				for (Map.Entry<String, Object> val : ((Document) customNode).entrySet()) {
 					currentRDF.add(v, plugin.vf.createIRI(MongoDBPlugin.NAMESPACE_INST, val.getKey()), plugin.vf.createLiteral(val.getValue().toString()));
 				}
 			}
+			dataAccumulator.accept(currentRDF);
+			return id;
 		} catch (RDFParseException | UnsupportedRDFormatException | IOException e) {
 			iter.close();
 			plugin.getLogger().error("Could not parse mongo document", e);
+			return 0;
 		}
 	}
 
@@ -409,6 +459,9 @@ public class MongoResultIterator extends StatementIterator {
 	}
 
 	protected boolean hasSolution() {
+		if (batched && !batchedLoading) {
+			return !interrupted && storeIterator != null && storeIterator.hasNext();
+		}
 		return !interrupted && iter != null && iter.hasNext();
 	}
 
@@ -499,6 +552,17 @@ public class MongoResultIterator extends StatementIterator {
 
 	public void setIndexId(long indexId) {
 		this.indexId = indexId;
+	}
+
+	public void setDocumentsLimit(int documentsLimit) {
+		if (documentsLimit > 0) {
+			batched = true;
+		}
+		this.documentsLimit = documentsLimit;
+	}
+
+	public int getDocumentsLimit() {
+		return documentsLimit;
 	}
 
 	public long getSearchSubject() {
@@ -626,6 +690,9 @@ public class MongoResultIterator extends StatementIterator {
 		hint = null;
 		modelIteratorCreated = false;
 		entityIteratorCreated = false;
+		if (batched) {
+			batchDocumentStore.clear();
+		}
 	}
 
 	public boolean isCloned() {

--- a/src/test/java/com/ontotext/trree/plugin/mongodb/AbstractMongoBasicTest.java
+++ b/src/test/java/com/ontotext/trree/plugin/mongodb/AbstractMongoBasicTest.java
@@ -1,22 +1,13 @@
 package com.ontotext.trree.plugin.mongodb;
 
+import static org.junit.Assert.assertEquals;
+
 import com.mongodb.client.FindIterable;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
 import com.ontotext.graphdb.Config;
 import com.ontotext.test.TemporaryLocalFolder;
-import org.bson.BsonArray;
-import org.bson.BsonValue;
-import org.bson.Document;
-import org.bson.conversions.Bson;
-import org.bson.types.ObjectId;
-import org.eclipse.rdf4j.query.GraphQuery;
-import org.eclipse.rdf4j.query.QueryResult;
-import org.eclipse.rdf4j.query.TupleQueryResult;
-import org.eclipse.rdf4j.repository.RepositoryConnection;
-import org.junit.*;
-
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.OutputStream;
@@ -32,8 +23,21 @@ import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
+import java.util.Map.Entry;
+import org.bson.BsonArray;
+import org.bson.BsonValue;
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.bson.types.ObjectId;
+import org.eclipse.rdf4j.query.GraphQuery;
+import org.eclipse.rdf4j.query.QueryResult;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
 
 /**
  * Convenient test case for the scenario: upload date to mongo, query it, verify the result.
@@ -65,6 +69,7 @@ public abstract class AbstractMongoBasicTest extends AbstractMongoTest {
 			INPUT_DIR = Paths.get("src", "test", "resources", "mongodb", "input");
 		}
 	}
+
 	protected static Path RESULTS_DIR;
 	static {
 		try {
@@ -107,7 +112,8 @@ public abstract class AbstractMongoBasicTest extends AbstractMongoTest {
 		Config.reset();
 	}
 
-	@Before
+    @Before
+	@Override
 	public void setup() {
 		super.setup();
 
@@ -115,7 +121,8 @@ public abstract class AbstractMongoBasicTest extends AbstractMongoTest {
 		loadData();
 	}
 
-	@After
+    @After
+	@Override
 	public void cleanup() {
 		disconnectFromMongoDB();
 		collection.drop();
@@ -124,34 +131,40 @@ public abstract class AbstractMongoBasicTest extends AbstractMongoTest {
 		super.cleanup();
 	}
 
-	/**
-	 * Executes a query and verifies the result count is correct
-	 *
-	 * @param query								query to be executed
-	 * @param expectedResultsCount
-	 */
-	protected void verifyResultsCount(String query, int expectedResultsCount) {
-		try (RepositoryConnection conn = getRepository().getConnection()) {
+    /**
+     * Executes a query and verifies the result count is correct
+     *
+     * @param query to be executed
+     * @param expectedResultsCount the results count
+     */
+    protected void verifyResultsCount(String query, int expectedResultsCount) {
+      try (RepositoryConnection conn = getRepository().getConnection()) {
 
-			TupleQueryResult iter = conn.prepareTupleQuery(query).evaluate();
+        TupleQueryResult result = conn.prepareTupleQuery(query).evaluate();
 
-			int countResults = 0;
-			while (iter.hasNext()) {
-				iter.next();
-				countResults++;
-			}
+        int countResults = 0;
+        while (result.hasNext()) {
+          result.next();
+          countResults++;
+        }
 
-			assertEquals("Iterator should return four results but were " + countResults, expectedResultsCount, countResults);
-		}
-	}
+        assertEquals("The results count differs", expectedResultsCount, countResults);
+      }
+    }
 
 	protected void verifyOrderedResult() throws Exception {
-		verifyResult(query, RESULTS_DIR.resolve(this.getClass().getSimpleName()).resolve(Thread.currentThread().getStackTrace()[2].getMethodName()).toFile(), true);
+      verifyResult(query, loadExpectedResult(), true);
 	}
 
-	protected void verifyUnorderedResult() throws Exception {
-		verifyResult(query, RESULTS_DIR.resolve(this.getClass().getSimpleName()).resolve(Thread.currentThread().getStackTrace()[2].getMethodName()).toFile(), false);
-	}
+    protected void verifyUnorderedResult() throws Exception {
+      verifyResult(query, loadExpectedResult(), false);
+    }
+
+    private File loadExpectedResult() {
+      return RESULTS_DIR.resolve(this.getClass().getSimpleName())
+          .resolve(Thread.currentThread().getStackTrace()[3].getMethodName())
+          .toFile();
+    }
 
 	/**
 	 * Executes a query verifies the output matches exactly a given one. Depending on the LEARN_MODE setting this method
@@ -183,13 +196,12 @@ public abstract class AbstractMongoBasicTest extends AbstractMongoTest {
 	protected void verifyResult(String query, File resultFile, boolean ordered) throws Exception {
 		try (RepositoryConnection conn = getRepository().getConnection()) {
 
-			QueryResult iter;
-
-			if (conn.prepareQuery(query) instanceof GraphQuery) {
-				iter = conn.prepareGraphQuery(query).evaluate();
-			} else {
-				iter = conn.prepareTupleQuery(query).evaluate();
-			}
+            QueryResult<?> iter;
+            if (conn.prepareQuery(query) instanceof GraphQuery) {
+              iter = conn.prepareGraphQuery(query).evaluate();
+            } else {
+              iter = conn.prepareTupleQuery(query).evaluate();
+            }
 
 			File actualFile = tmpFolder.newFile(resultFile.getName() + "_actual");
 			File writeTo = isLearnMode() ? resultFile : actualFile;
@@ -197,6 +209,7 @@ public abstract class AbstractMongoBasicTest extends AbstractMongoTest {
 				writeTo.getParentFile().mkdirs();
 				writeTo.createNewFile();
 			}
+
 			try (OutputStream os = new FileOutputStream(writeTo)) {
 				while (iter.hasNext()) {
 					String bs = iter.next().toString()
@@ -207,21 +220,26 @@ public abstract class AbstractMongoBasicTest extends AbstractMongoTest {
 				}
 			}
 
-			if (!isLearnMode()) {
-				List<String> exp = Files.readAllLines(resultFile.toPath(), StandardCharsets.UTF_8);
-				List<String> act = Files.readAllLines(actualFile.toPath(), StandardCharsets.UTF_8);
+            if (isLearnMode()) {
+              return;
+            }
 
-				if (!ordered) {
-					exp.sort(String::compareTo);
-					act.sort(String::compareTo);
-				}
+            List<String> exp = Files.readAllLines(resultFile.toPath(), StandardCharsets.UTF_8);
+            List<String> act = Files.readAllLines(actualFile.toPath(), StandardCharsets.UTF_8);
 
-				assertEquals("Number of results", exp, act);
+            if (!ordered) {
+              exp.sort(String::compareTo);
+              act.sort(String::compareTo);
+            }
 
-				for (int i = 0; i < act.size(); i++) {
-					assertEquals("Result record is as expected", exp.get(i), act.get(i));
-				}
-			}
+
+            assertEquals("The number of results differs", exp.size(), act.size());
+
+            for (int i = 0; i < act.size(); i++) {
+              String expected = exp.get(i).replace("[null]", "").trim();
+              String actual = act.get(i).replace("[null]", "").trim();
+              assertEquals("Result record isn't as expected", expected, actual);
+            }
 		}
 	}
 
@@ -235,7 +253,7 @@ public abstract class AbstractMongoBasicTest extends AbstractMongoTest {
 	 * @param inputFolder
 	 */
 	protected void loadFilesToMongo(File inputFolder) {
-		List<Document> batch = new LinkedList<Document>();
+		List<Document> batch = new LinkedList<>();
 
 		for (File file : inputFolder.listFiles()) {
 			if (file.isDirectory()) {
@@ -270,21 +288,25 @@ public abstract class AbstractMongoBasicTest extends AbstractMongoTest {
 		return false;
 	}
 
-	protected void addMongoDates() {
+    @SuppressWarnings("unchecked")
+    protected void addMongoDates() {
 		FindIterable<Document> documents = collection.find();
 
 		try {
 			for (Document doc : documents) {
 				ObjectId id = doc.getObjectId("_id");
 				List<Map<String, Object>> graph = (List<Map<String, Object>>) doc.get("@graph");
+				if (graph == null) {
+					continue;
+				}
 
-				for (Map.Entry currentValue : graph.get(0).entrySet()) {
+                for (Entry<String, Object> currentValue : graph.get(0).entrySet()) {
 					Object object = graph.get(0).get(currentValue.getKey());
 
 					if (object instanceof Document) {
 						addMongoDates((Document) object, id, currentValue.getKey().toString());
 					} else if(object instanceof ArrayList) {
-						addMongoDates((ArrayList<Object>) object, id, currentValue.getKey().toString());
+                      addMongoDates((List<Object>) object, id, currentValue.getKey().toString());
 					}
 				}
 			}
@@ -293,10 +315,11 @@ public abstract class AbstractMongoBasicTest extends AbstractMongoTest {
 		}
 	}
 
-	private void addMongoDates(ArrayList<Object> objects, ObjectId objectId, String prefix) throws ParseException {
+    @SuppressWarnings("unchecked")
+    private void addMongoDates(List<Object> objects, ObjectId objectId, String prefix) throws ParseException {
 		for (Object object : objects) {
 			if (object instanceof Document) {
-				for (Map.Entry currentValue : ((Document) object).entrySet()) {
+              for (Entry<String, Object> currentValue : ((Document) object).entrySet()) {
 					StringBuilder sb = new StringBuilder();
 					sb.append(prefix);
 					if (currentValue.getValue() instanceof Document) {
@@ -304,7 +327,7 @@ public abstract class AbstractMongoBasicTest extends AbstractMongoTest {
 						addMongoDates((Document) currentValue.getValue(), objectId, sb.toString());
 					} else if (currentValue.getValue() instanceof ArrayList) {
 						sb.append("[" + currentValue.getKey().toString());
-						addMongoDates((ArrayList<Object>) currentValue.getValue(), objectId, sb.toString());
+                        addMongoDates((List<Object>) currentValue.getValue(), objectId, sb.toString());
 					}
 				}
 			}

--- a/src/test/java/com/ontotext/trree/plugin/mongodb/TestPluginMongoBasicQueries.java
+++ b/src/test/java/com/ontotext/trree/plugin/mongodb/TestPluginMongoBasicQueries.java
@@ -85,11 +85,11 @@ public class TestPluginMongoBasicQueries extends AbstractMongoBasicTest {
 
 	@Test
 	public void testAggregation() throws Exception {
-		query = "PREFIX : <http://www.ontotext.com/connectors/mongodb#>\r\n" +
-				"PREFIX inst: <http://www.ontotext.com/connectors/mongodb/instance#>\r\n" +
-				"select distinct ?entity {\n"
+		query = "PREFIX : <http://www.ontotext.com/connectors/mongodb#>\r\n"
+	            + "PREFIX inst: <http://www.ontotext.com/connectors/mongodb/instance#>\r\n"
+		        + "select distinct ?entity {\n"
 				+ "\t?search a inst:spb100 ;\n"
-				+ "\t:aggregate \"[{'$match': {}}, {'$sort': {'@id': 1}}, {'$limit': 2}]\" ;"
+				+ "\t:aggregate \"[{'$match': {}}, {'$sort': {'@id': 1}}, {'$limit': 2}]\" ;\n"
 				+ "\t:entity ?entity .\n"
 				+ "\tgraph inst:spb100 {\n"
 				+ "\t\t?s ?p ?o .\n"

--- a/src/test/java/com/ontotext/trree/plugin/mongodb/TestPluginMongoBatchedQueries.java
+++ b/src/test/java/com/ontotext/trree/plugin/mongodb/TestPluginMongoBatchedQueries.java
@@ -1,0 +1,134 @@
+package com.ontotext.trree.plugin.mongodb;
+
+import com.ontotext.test.utils.StandardUtils;
+import org.eclipse.rdf4j.repository.config.RepositoryConfig;
+import org.junit.Test;
+
+public class TestPluginMongoBatchedQueries extends AbstractMongoBasicTest {
+
+  @Override
+  protected void loadData() {
+    loadFilesToMongo();
+    addMongoDates();
+  }
+
+  @Override
+  protected RepositoryConfig createRepositoryConfiguration() {
+    return StandardUtils.createOwlimSe("empty");
+  }
+
+  @Test
+  public void testResultsAreJoined() throws Exception {
+    query = "PREFIX mongodb-index: <http://www.ontotext.com/connectors/mongodb/instance#>\n"
+        + "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n"
+        + "PREFIX mongodb: <http://www.ontotext.com/connectors/mongodb#>\n"
+        + "PREFIX skos:  <http://www.w3.org/2004/02/skos/core#>\n"
+        + "PREFIX atlas: <https://id.roche.com/am/sc/at/>\n"
+        + "PREFIX prov: <http://www.w3.org/ns/prov#>\n"
+        + "PREFIX dct: <http://purl.org/dc/terms/>\n"
+        + "SELECT distinct * WHERE {\n"
+        + "    \n"
+        + "    {\n"
+        + "        [] a mongodb-index:spb100 ;\n"
+        + "        mongodb:batchSize 100 ;\n"
+        + "        mongodb:find '{}' ;\n"
+        + "        mongodb:entity [] .   \n"
+        + "\n"
+        + "        GRAPH mongodb-index:spb100 {\n"
+        + "            ?study skos:prefLabel ?st_label .\n"
+        + "            ?study prov:hadPrimarySource ?cr_study .\n"
+        + "            ?study ^dct:isPartOf ?act .\n"
+        + "        }\n"
+        + "    }    \n"
+        + "}";
+
+    verifyUnorderedResult();
+  }
+
+  /**
+   * Test the lazy version of the batch definition.
+   */
+  @Test
+  public void testResultsAreJoined_inverseDef() throws Exception {
+    query = "PREFIX mongodb-index: <http://www.ontotext.com/connectors/mongodb/instance#>\n"
+        + "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n"
+        + "PREFIX mongodb: <http://www.ontotext.com/connectors/mongodb#>\n"
+        + "PREFIX skos:  <http://www.w3.org/2004/02/skos/core#>\n"
+        + "PREFIX atlas: <https://id.roche.com/am/sc/at/>\n"
+        + "PREFIX prov: <http://www.w3.org/ns/prov#>\n"
+        + "PREFIX dct: <http://purl.org/dc/terms/>\n"
+        + "SELECT distinct * WHERE {\n"
+        + "    \n"
+        + "    {\n"
+        + "        GRAPH mongodb-index:spb100 {\n"
+        + "            ?study skos:prefLabel ?st_label .\n"
+        + "            ?study prov:hadPrimarySource ?cr_study .\n"
+        + "            ?study ^dct:isPartOf ?act .\n"
+        + "        }\n"
+        + "\n"
+        + "        [] a mongodb-index:spb100 ;\n"
+        + "        mongodb:batchSize 100 ;\n"
+        + "        mongodb:find '{}' ;\n"
+        + "        mongodb:entity [] .   \n"
+        + "    }    \n"
+        + "}";
+
+    verifyUnorderedResult();
+  }
+
+  @Test
+  public void testBadConfig() throws Exception {
+    query = "PREFIX mongodb-index: <http://www.ontotext.com/connectors/mongodb/instance#>\n"
+        + "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n"
+        + "PREFIX mongodb: <http://www.ontotext.com/connectors/mongodb#>\n"
+        + "PREFIX skos:  <http://www.w3.org/2004/02/skos/core#>\n"
+        + "PREFIX atlas: <https://id.roche.com/am/sc/at/>\n"
+        + "PREFIX prov: <http://www.w3.org/ns/prov#>\n"
+        + "PREFIX dct: <http://purl.org/dc/terms/>\n"
+        + "SELECT distinct * WHERE {\n"
+        + "    \n"
+        + "    {\n"
+        + "        [] a mongodb-index:spb100 ;\n"
+        + "        mongodb:batchSize \"-1\" ;\n"
+        + "        mongodb:find '{}' ;\n"
+        + "        mongodb:entity [] .   \n"
+        + "\n"
+        + "        GRAPH mongodb-index:spb100 {\n"
+        + "            ?study skos:prefLabel ?st_label .\n"
+        + "            ?study prov:hadPrimarySource ?cr_study .\n"
+        + "            ?study ^dct:isPartOf ?act .\n"
+        + "        }\n"
+        + "" + "    }    \n"
+        + "}";
+
+    verifyUnorderedResult();
+  }
+
+  @Test
+  public void testClientExactCase() throws Exception {
+    query = "PREFIX mongodb-index: <http://www.ontotext.com/connectors/mongodb/instance#>\n"
+        + "PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>\n"
+        + "PREFIX mongodb: <http://www.ontotext.com/connectors/mongodb#>\n"
+        + "PREFIX skos:  <http://www.w3.org/2004/02/skos/core#>\n"
+        + "PREFIX atlas: <https://id.roche.com/am/sc/at/>\n"
+        + "PREFIX prov: <http://www.w3.org/ns/prov#>\n"
+        + "PREFIX dct: <http://purl.org/dc/terms/>\n"
+        + "SELECT distinct * WHERE {\n"
+        + "    \n"
+        + "    {\n"
+        + "        [] a mongodb-index:spb100 ;\n"
+        + "        mongodb:batchSize 100 ;\n"
+        + "        mongodb:find '{}' ;\n"
+        + "        mongodb:entity [] .   \n"
+        + "\n"
+        + "        GRAPH mongodb-index:spb100 {\n"
+        + "            values ?cr_study { <https://id.roche.com/am/a3/jkmxqmxfd296b3k8f6sztmsd67kt> } \n"
+        + "            ?study prov:hadPrimarySource ?cr_study .\n"
+        + "            ?study ^dct:isPartOf ?act .\n"
+        + "        }\n"
+        + "    }    \n"
+        + "}";
+
+    verifyUnorderedResult();
+  }
+}

--- a/src/test/java/com/ontotext/trree/plugin/mongodb/TestPluginMongoCollationQueries.java
+++ b/src/test/java/com/ontotext/trree/plugin/mongodb/TestPluginMongoCollationQueries.java
@@ -1,14 +1,10 @@
 package com.ontotext.trree.plugin.mongodb;
 
-import java.util.Arrays;
-import java.util.List;
-
-import org.eclipse.rdf4j.repository.config.RepositoryConfig;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import com.ontotext.test.utils.StandardUtils;
-
-import static org.junit.Assert.assertEquals;
+import org.eclipse.rdf4j.repository.config.RepositoryConfig;
+import org.junit.Test;
 
 public class TestPluginMongoCollationQueries extends AbstractMongoBasicTest {
 

--- a/src/test/java/com/ontotext/trree/plugin/mongodb/TestPluginMongoExtended.java
+++ b/src/test/java/com/ontotext/trree/plugin/mongodb/TestPluginMongoExtended.java
@@ -17,12 +17,11 @@ public class TestPluginMongoExtended extends AbstractMongoBasicTest {
 	 */
 	@Test
 	public void testJsonLdWithAndWithoutContexts() {
-
-		String query = "PREFIX : <http://www.ontotext.com/connectors/mongodb#>\r\n" +
-				"PREFIX inst: <http://www.ontotext.com/connectors/mongodb/instance#>\r\n" +
-				"select distinct ?entity {\n"
+		String query = "PREFIX : <http://www.ontotext.com/connectors/mongodb#>\r\n"
+		        + "PREFIX inst: <http://www.ontotext.com/connectors/mongodb/instance#>\r\n"
+		        + "select distinct ?entity {\n"
 				+ "\t?search a inst:spb100 ;\n"
-				+ "\t:find \"{}\" ;"
+				+ "\t:find \"{}\" ;\n"
 				+ "\t:entity ?entity .\n"
 				+ "\tgraph inst:spb100 {\n"
 				+ "\t\t?s ?p ?o .\n"

--- a/src/test/resources/mongodb/input/TestPluginMongoBatchedQueries/file1.jsonld
+++ b/src/test/resources/mongodb/input/TestPluginMongoBatchedQueries/file1.jsonld
@@ -1,0 +1,22 @@
+{
+  "@context": {
+    "@base": "https://id.roche.com/am/a6/",
+    "@vocab": "https://id.roche.com/am/sc/at/",
+    "dct": "http://purl.org/dc/terms/",
+    "prov": "http://www.w3.org/ns/prov#",
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "type": "@type",
+    "_id": "@nest",
+    "relationship_entity": "dct:isPartOf",
+    "name": "skos:prefLabel",
+    "created_by": "dct:creator",
+    "coralreef_uri": {
+      "@type": "@id",
+      "@id": "prov:hadPrimarySource"
+    }
+  },
+  "name": "YO42311",
+  "type": "Study",
+  "@id": "6568f1aebd1e4f12a0c3d9a1",
+  "coralreef_uri": "https://id.roche.com/am/a3/jkmxqmxfd296b3k8f6sztmsd67kt"
+}

--- a/src/test/resources/mongodb/input/TestPluginMongoBatchedQueries/file2.jsonld
+++ b/src/test/resources/mongodb/input/TestPluginMongoBatchedQueries/file2.jsonld
@@ -1,0 +1,27 @@
+{
+  "@context": {
+    "@base": "https://id.roche.com/am/a6/",
+    "@vocab": "https://id.roche.com/am/sc/at/",
+    "dct": "http://purl.org/dc/terms/",
+    "prov": "http://www.w3.org/ns/prov#",
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "type": "@type",
+    "_id": "@nest",
+    "relationship_entity": "dct:isPartOf",
+    "name": "skos:prefLabel",
+    "created_by": "dct:creator",
+    "coralreef_uri": {
+      "@type": "@id",
+      "@id": "prov:hadPrimarySource"
+    }
+  },
+  "name": "CSRFinal_ADS",
+  "type": "Activity",
+  "@id": "6568f1aebf5d4e12c7d3e8b3",
+  "relationship_entity": {
+    "@id": "6568f1aebd1e4f12a0c3d9a1",
+    "type": "Study",
+    "name": "YO42311"
+  },
+  "coralreef_uri": "https://id.roche.com/am/a3/ng987gby2hn32z69746x"
+}

--- a/src/test/resources/mongodb/input/TestPluginMongoBatchedQueries/file3.jsonld
+++ b/src/test/resources/mongodb/input/TestPluginMongoBatchedQueries/file3.jsonld
@@ -1,0 +1,27 @@
+{
+  "@context": {
+    "@base": "https://id.roche.com/am/a6/",
+    "@vocab": "https://id.roche.com/am/sc/at/",
+    "dct": "http://purl.org/dc/terms/",
+    "prov": "http://www.w3.org/ns/prov#",
+    "skos": "http://www.w3.org/2004/02/skos/core#",
+    "type": "@type",
+    "_id": "@nest",
+    "relationship_entity": "dct:isPartOf",
+    "name": "skos:prefLabel",
+    "created_by": "dct:creator",
+    "coralreef_uri": {
+      "@type": "@id",
+      "@id": "prov:hadPrimarySource"
+    }
+  },
+  "name": "CSRUpdate_SDTMv_dp",
+  "type": "Activity",
+  "@id": "6568f1aecb2e4f12d9e3c7b4",
+  "relationship_entity": {
+    "@id": "6568f1aebd1e4f12a0c3d9a1",
+    "type": "Study",
+    "name": "YO42311"
+  },
+  "coralreef_uri": "https://id.roche.com/am/a3/ng4gskyq7qp7c9g4pg8s"
+}

--- a/src/test/resources/mongodb/results/TestPluginMongoBasicQueries/shouldWorkWithUNION_customGraphs_example_2
+++ b/src/test/resources/mongodb/results/TestPluginMongoBasicQueries/shouldWorkWithUNION_customGraphs_example_2
@@ -1,0 +1,2 @@
+[s1=http://www.bbc.co.uk/things/1646461#id;o1=http://www.bbc.co.uk/ontologies/creativework/BlogPost]
+[s2=http://www.bbc.co.uk/things/1646453#id;o2=http://www.bbc.co.uk/ontologies/creativework/BlogPost]

--- a/src/test/resources/mongodb/results/TestPluginMongoBatchedQueries/testClientExactCase
+++ b/src/test/resources/mongodb/results/TestPluginMongoBatchedQueries/testClientExactCase
@@ -1,0 +1,2 @@
+[cr_study=https://id.roche.com/am/a3/jkmxqmxfd296b3k8f6sztmsd67kt;study=https://id.roche.com/am/a6/6568f1aebd1e4f12a0c3d9a1;act=https://id.roche.com/am/a6/6568f1aebf5d4e12c7d3e8b3]
+[cr_study=https://id.roche.com/am/a3/jkmxqmxfd296b3k8f6sztmsd67kt;study=https://id.roche.com/am/a6/6568f1aebd1e4f12a0c3d9a1;act=https://id.roche.com/am/a6/6568f1aecb2e4f12d9e3c7b4]

--- a/src/test/resources/mongodb/results/TestPluginMongoBatchedQueries/testResultsAreJoined
+++ b/src/test/resources/mongodb/results/TestPluginMongoBatchedQueries/testResultsAreJoined
@@ -1,0 +1,2 @@
+[study=https://id.roche.com/am/a6/6568f1aebd1e4f12a0c3d9a1;st_label="YO42311";cr_study=https://id.roche.com/am/a3/jkmxqmxfd296b3k8f6sztmsd67kt;act=https://id.roche.com/am/a6/6568f1aebf5d4e12c7d3e8b3]
+[study=https://id.roche.com/am/a6/6568f1aebd1e4f12a0c3d9a1;st_label="YO42311";cr_study=https://id.roche.com/am/a3/jkmxqmxfd296b3k8f6sztmsd67kt;act=https://id.roche.com/am/a6/6568f1aecb2e4f12d9e3c7b4]

--- a/src/test/resources/mongodb/results/TestPluginMongoBatchedQueries/testResultsAreJoined_inverseDef
+++ b/src/test/resources/mongodb/results/TestPluginMongoBatchedQueries/testResultsAreJoined_inverseDef
@@ -1,0 +1,2 @@
+[study=https://id.roche.com/am/a6/6568f1aebd1e4f12a0c3d9a1;st_label="YO42311";cr_study=https://id.roche.com/am/a3/jkmxqmxfd296b3k8f6sztmsd67kt;act=https://id.roche.com/am/a6/6568f1aebf5d4e12c7d3e8b3]
+[study=https://id.roche.com/am/a6/6568f1aebd1e4f12a0c3d9a1;st_label="YO42311";cr_study=https://id.roche.com/am/a3/jkmxqmxfd296b3k8f6sztmsd67kt;act=https://id.roche.com/am/a6/6568f1aecb2e4f12d9e3c7b4]


### PR DESCRIPTION
- Added functionality where all documents matching the input query, up to a maximum are loaded in memory and returned as named graph collection instead of processing one by one.

  When the new functionality is used the plugin is no longer streaming
but will require a buffer to store the documents until the query is complete.

- Added system property configuration that controls the maximum allowed batch size: `graphdb.mongodb.maxBatchSize`. This is to prevent OOM problems.

- Added CHANGELOG file.

- Added `.gitignore` file.

- Updated the version of the GraphDB SDK to `10.8.7` and the Java version to 11.