### PR TITLE
Fixes wrong import which causes problems

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,8 @@
 
 		<java.level>21</java.level>
 
+		<eclipse-collections.version>11.1.0</eclipse-collections.version>
+
 		<internal.repo>https://maven.ontotext.com/content/repositories/owlim-releases</internal.repo>
 		<snapshots.repo>https://maven.ontotext.com/content/repositories/owlim-snapshots</snapshots.repo>
 
@@ -136,7 +138,13 @@
 		<dependency>
 			<groupId>org.eclipse.collections</groupId>
 			<artifactId>eclipse-collections-api</artifactId>
-			<version>11.1.0</version>
+			<version>${eclipse-collections.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.eclipse.collections</groupId>
+			<artifactId>eclipse-collections</artifactId>
+			<version>${eclipse-collections.version}</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/com/ontotext/trree/plugin/mongodb/BatchDocumentStore.java
+++ b/src/main/java/com/ontotext/trree/plugin/mongodb/BatchDocumentStore.java
@@ -2,7 +2,7 @@ package com.ontotext.trree.plugin.mongodb;
 
 import org.eclipse.collections.api.iterator.LongIterator;
 import org.eclipse.collections.api.set.primitive.MutableLongSet;
-import org.eclipse.collections.api.factory.primitive.LongSets;
+import org.eclipse.collections.impl.factory.primitive.LongSets;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.impl.LinkedHashModel;
 


### PR DESCRIPTION
- A wrong class was imported when instantiating LongSets from `eclipse-collections` library. It was causing class loading issues when trying to use the related functionalities.